### PR TITLE
Add LoadInfo interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ in collaborating.
 
 Services implement [rangelet.Node](pkg/rangelet/interface.go):
 
+- `GetLoadInfo(rID ranje.Ident) LoadInfo`
 - `PrepareAddRange(rm RangeMeta, parents []Parent) error`
 - `AddRange(rid RangeID) error`
 - `PrepareDropRange(rid RangeID) error`

--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -12,13 +12,13 @@ import (
 	"github.com/adammck/ranger/pkg/ranje"
 )
 
-func (n *Node) GetLoadInfo(rID ranje.Ident) rangelet.LoadInfo {
+func (n *Node) GetLoadInfo(rID ranje.Ident) (rangelet.LoadInfo, error) {
 	n.rangesMu.RLock()
 	defer n.rangesMu.RUnlock()
 
 	r, ok := n.ranges[rID]
 	if !ok {
-		panic("GetLoad with unknown range!")
+		return rangelet.LoadInfo{}, rangelet.NotFound
 	}
 
 	r.dataMu.RLock()
@@ -27,7 +27,7 @@ func (n *Node) GetLoadInfo(rID ranje.Ident) rangelet.LoadInfo {
 
 	return rangelet.LoadInfo{
 		Keys: keys,
-	}
+	}, nil
 }
 
 // PrepareAddRange: Create the range, but don't do anything with it yet.

--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -12,6 +12,24 @@ import (
 	"github.com/adammck/ranger/pkg/ranje"
 )
 
+func (n *Node) GetLoadInfo(rID ranje.Ident) rangelet.LoadInfo {
+	n.rangesMu.RLock()
+	defer n.rangesMu.RUnlock()
+
+	r, ok := n.ranges[rID]
+	if !ok {
+		panic("GetLoad with unknown range!")
+	}
+
+	r.dataMu.RLock()
+	defer r.dataMu.RUnlock()
+	keys := len(r.data)
+
+	return rangelet.LoadInfo{
+		Keys: keys,
+	}
+}
+
 // PrepareAddRange: Create the range, but don't do anything with it yet.
 func (n *Node) PrepareAddRange(rm ranje.Meta, parents []rangelet.Parent) error {
 	if err := n.performChaos(); err != nil {

--- a/examples/kv/pkg/proxy/server.go
+++ b/examples/kv/pkg/proxy/server.go
@@ -58,7 +58,7 @@ func (ps *proxyServer) getClient(k string, write bool) (pbkv.KVClient, roster.Lo
 
 	client, ok := ps.proxy.clients[loc.Node]
 	if !ok {
-		return nil, loc, status.Errorf(codes.FailedPrecondition, "no client for node id %s?", loc)
+		return nil, loc, status.Errorf(codes.FailedPrecondition, "no client for node id %s?", loc.Node)
 	}
 
 	return client, loc, nil

--- a/pkg/proto/debug.proto
+++ b/pkg/proto/debug.proto
@@ -17,10 +17,17 @@ message RangeRequest {
   uint64 range = 1;
 }
 
+// Similar to Placement (from ranje.proto), but includes extra junk for debug
+// views. The other one is used on the control plane, so should be minimal.
+message PlacementWithRangeInfo {
+  Placement placement = 1;
+  RangeInfo range_info = 2;
+}
+
 message RangeResponse {
   RangeMeta meta = 1;
   RangeState state = 2;
-  repeated Placement placements = 3;
+  repeated PlacementWithRangeInfo placements = 3;
 }
 
 message NodesListRequest {
@@ -40,6 +47,7 @@ message NodeMeta {
   bool want_drain = 3;
 }
 
+// TODO: Remove this, and use PlacementWithRangeInfo
 message NodeRange {
   RangeMeta meta = 1;
   PlacementState state = 3;

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -13,6 +13,7 @@ message RangeMeta {
   bytes end = 3; // exclusive
 }
 
+// Sent from the controller when PrepareAddRange.
 // TODO: Should include the placement index in here, so the node can verify that
 //       the controller is talking about the same placement when it sees
 //       duplicates. Just in case the controller has gone mad and is trying to
@@ -22,21 +23,33 @@ message Placement {
   PlacementState state = 2;
 }
 
-message RangeInfo {
-  RangeMeta meta = 1;
-  
-  // The state which the range is currently in, according to the node.
-  RangeNodeState state = 2;
-  
+// Proto of rangelet.LoadInfo and roster.LoadInfo
+message LoadInfo {
   // Number of keys which this range contains.
   // Just for reporting? Not balancing?
-  uint64 keys = 3;
-  
+  uint64 keys = 1;
+
   // TODO: Generic load info? cpu/ram/network/disk?
   // TODO: Extra domain-specific info?
   // TODO: Suggested split point(s)
-  }
+}
 
+// TODO: Rename to RemoteRangeInfo, since this is the view from the remote.
+message RangeInfo {
+  // TODO: Do we need the whole meta here? Maybe ID is enough?
+  //       Nice to confirm range boundaries I guess.
+  RangeMeta meta = 1;
+
+  // The state which the range is currently in, according to the node.
+  RangeNodeState state = 2;
+
+  // LoadInfo informs the controller how much load this range is applying to the
+  // node, relative to the other ranges on that node. The controller will use
+  // this info to rebalance ranges.
+  LoadInfo info = 3;
+ }
+
+ // TODO: Rename to RemoteState, like the non-proto type.
 // Keep synced with RangeState (in node.go for now)
 enum RangeNodeState {
   UNKNOWN = 0;

--- a/pkg/rangelet/interface.go
+++ b/pkg/rangelet/interface.go
@@ -18,7 +18,7 @@ type Parent struct {
 	Placements []Placement
 }
 
-// See also roster/info.RangeInfo
+// Same as roster/info.LoadInfo, to avoid circular import.
 type LoadInfo struct {
 	Keys int
 }

--- a/pkg/rangelet/interface.go
+++ b/pkg/rangelet/interface.go
@@ -16,6 +16,10 @@ type Parent struct {
 	Placements []Placement
 }
 
+type LoadInfo struct {
+	Keys int
+}
+
 type Storage interface {
 	Read() []*info.RangeInfo
 	Write()
@@ -25,6 +29,9 @@ type Storage interface {
 // Ranger, but Shard Manager uses roughly (s/Shard/Range/g) these terms. Better
 // to follow those than invent our own.
 type Node interface {
+
+	// GetLoadInfo returns the LoadInfo for the given range.
+	GetLoadInfo(rID ranje.Ident) LoadInfo
 
 	// PrepareAddRange.
 	PrepareAddRange(m ranje.Meta, p []Parent) error

--- a/pkg/rangelet/interface.go
+++ b/pkg/rangelet/interface.go
@@ -25,6 +25,7 @@ type LoadInfo struct {
 
 type Storage interface {
 	// TODO: Return a rangelet-only type, to avoid importing the whole roster.
+	// TODO: Return info.RangeInfo instead! Pointer is pointless.
 	Read() []*info.RangeInfo
 	Write()
 }

--- a/pkg/rangelet/server.go
+++ b/pkg/rangelet/server.go
@@ -137,6 +137,11 @@ func (ns *NodeServer) Drop(ctx context.Context, req *pb.DropRequest) (*pb.DropRe
 }
 
 func (ns *NodeServer) Info(ctx context.Context, req *pb.InfoRequest) (*pb.InfoResponse, error) {
+	err := ns.r.gatherLoadInfo()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	res := &pb.InfoResponse{
 		WantDrain: ns.r.wantDrain(),
 	}

--- a/pkg/roster/info/info.go
+++ b/pkg/roster/info/info.go
@@ -21,18 +21,38 @@ type NodeInfo struct {
 	Expired bool
 }
 
+// Same as rangelet.LoadInfo
+// TODO: Would be nice to just use a rangelet.LoadInfo here, but circular
+//       import! Remove roster/info import from rangelet, then resolve this.
+type LoadInfo struct {
+	Keys uint64
+}
+
+func (li *LoadInfo) ToProto() *pb.LoadInfo {
+	return &pb.LoadInfo{
+		Keys: li.Keys,
+	}
+}
+
+func LoadInfoFromProto(pbli *pb.LoadInfo) LoadInfo {
+	return LoadInfo{
+		Keys: pbli.Keys,
+	}
+}
+
 // RangeInfo represents something we know about a Range on a Node at a moment in
 // time. These are emitted and cached by the Roster to anyone who cares.
 type RangeInfo struct {
 	Meta  ranje.Meta
 	State state.RemoteState
-	// TODO: LoadInfo goes here!!
+	Info  LoadInfo
 }
 
 func (ri *RangeInfo) ToProto() *pb.RangeInfo {
 	return &pb.RangeInfo{
 		Meta:  ri.Meta.ToProto(),
 		State: ri.State.ToProto(),
+		Info:  ri.Info.ToProto(),
 	}
 }
 
@@ -46,10 +66,9 @@ func RangeInfoFromProto(r *pb.RangeInfo) (RangeInfo, error) {
 		return RangeInfo{}, fmt.Errorf("parsing meta: %v", err)
 	}
 
-	// TODO: Update the map rather than overwriting it every time.
 	return RangeInfo{
 		Meta:  *m,
 		State: state.RemoteStateFromProto(r.State),
-		// TODO: LoadInfo
+		Info:  LoadInfoFromProto(r.Info),
 	}, nil
 }

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -103,10 +103,10 @@ func (n *TestNode) waitUntil(rID ranje.Ident, src state.RemoteState) error {
 	}
 }
 
-func (n *TestNode) GetLoadInfo(rID ranje.Ident) rangelet.LoadInfo {
+func (n *TestNode) GetLoadInfo(rID ranje.Ident) (rangelet.LoadInfo, error) {
 	return rangelet.LoadInfo{
 		Keys: 0,
-	}
+	}, nil
 }
 
 func (n *TestNode) PrepareAddRange(m ranje.Meta, p []rangelet.Parent) error {

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -103,6 +103,12 @@ func (n *TestNode) waitUntil(rID ranje.Ident, src state.RemoteState) error {
 	}
 }
 
+func (n *TestNode) GetLoadInfo(rID ranje.Ident) rangelet.LoadInfo {
+	return rangelet.LoadInfo{
+		Keys: 0,
+	}
+}
+
 func (n *TestNode) PrepareAddRange(m ranje.Meta, p []rangelet.Parent) error {
 	return n.waitUntil(m.Ident, state.NsPreparing)
 }

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -29,6 +29,8 @@ type TestNode struct {
 	Conn *grpc.ClientConn
 	rglt *rangelet.Rangelet
 
+	loadInfos map[ranje.Ident]rangelet.LoadInfo
+
 	// Keep requests sent to this node.
 	// Call RPCs() to fetch and clear.
 	rpcs   []interface{}
@@ -44,15 +46,31 @@ type TestNode struct {
 }
 
 func NewTestNode(ctx context.Context, addr string, rangeInfos map[ranje.Ident]*info.RangeInfo) (*TestNode, func()) {
+
+	// Copy rangeInfos to be loaded (via Storage) into rangelet.
+	// TODO: This allows test to mess with RangeInfo; get rid of the pointers.
 	infos := []*info.RangeInfo{}
 	for _, ri := range rangeInfos {
-		infos = append(infos, ri)
+		infos = append(infos, &info.RangeInfo{
+			Meta:  ri.Meta,
+			State: ri.State,
+		})
+	}
+
+	// Extract LoadInfos to keep in the client (TestNode). Rangelet fetches via
+	// GetLoadInfo.
+	li := map[ranje.Ident]rangelet.LoadInfo{}
+	for _, ri := range rangeInfos {
+		li[ri.Meta.Ident] = rangelet.LoadInfo{
+			Keys: int(ri.Info.Keys),
+		}
 	}
 
 	srv := grpc.NewServer()
 
 	tn := &TestNode{
 		Addr:        addr,
+		loadInfos:   li,
 		gates:       map[string][2]*sync.WaitGroup{},
 		transitions: map[rangeInState]error{},
 	}
@@ -104,9 +122,12 @@ func (n *TestNode) waitUntil(rID ranje.Ident, src state.RemoteState) error {
 }
 
 func (n *TestNode) GetLoadInfo(rID ranje.Ident) (rangelet.LoadInfo, error) {
-	return rangelet.LoadInfo{
-		Keys: 0,
-	}, nil
+	li, ok := n.loadInfos[rID]
+	if !ok {
+		return rangelet.LoadInfo{}, rangelet.NotFound
+	}
+
+	return li, nil
 }
 
 func (n *TestNode) PrepareAddRange(m ranje.Meta, p []rangelet.Parent) error {


### PR DESCRIPTION
This adds the following method to the `rangelet.Node` interface:

```go
GetLoadInfo(rID ranje.Ident) LoadInfo
```

LoadInfo currently just contains "keys", as in the number of keys in this range. This isn't universally applicable (some clients may not have discrete keys, only ranges) but I think is fine for now. Other stuff like utilization metrics (cpu, mem, etc) can also go in there, but I haven't really thought about how that would work yet.

I'm not sure if suggested splits belongs in the LoadInfo or whether that should be calculated on demand, once the controller decides to split, via some other interface method. Probably they're cheap enough to just stick them in the LoadInfo. Clients can always cache them.

This is fun to test manually.
In three separate windows/tabs:

```
bin/dev.sh
cd examples/kv; while true; do clear ; ./rangerctl ranges; sleep 0.5; done
cd examples/kv/tools/hammer; ./hammer -addr 127.0.0.1:5100
```
