### PR TITLE
Improve split/join workflow

### DIFF
--- a/cmd/rangerctl/main.go
+++ b/cmd/rangerctl/main.go
@@ -27,9 +27,9 @@ func main() {
 		fmt.Fprintf(w, "  - range <rangeID>\n")
 		fmt.Fprintf(w, "  - nodes\n")
 		fmt.Fprintf(w, "  - node <nodeID>\n")
-		fmt.Fprintf(w, "  - move <rangeID> <nodeID>\n")
+		fmt.Fprintf(w, "  - move <rangeID> [<nodeID>]\n")
 		fmt.Fprintf(w, "  - split <rangeID> <boundary> [<nodeID>] [<nodeID>]\n")
-		fmt.Fprintf(w, "  - join <rangeID> <rangeID> <nodeID>\n")
+		fmt.Fprintf(w, "  - join <rangeID> <rangeID> [<nodeID>]\n")
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "Flags:\n")
 		flag.PrintDefaults()
@@ -101,8 +101,8 @@ func main() {
 		cmdNode(*printReq, client, ctx, flag.Arg(1))
 
 	case "move", "m":
-		if flag.NArg() != 3 {
-			fmt.Fprintf(w, "Usage: %s move <rangeID> <nodeID>\n", os.Args[0])
+		if flag.NArg() < 2 || flag.NArg() > 3 {
+			fmt.Fprintf(w, "Usage: %s move <rangeID> [<nodeID>]\n", os.Args[0])
 			os.Exit(1)
 		}
 

--- a/cmd/rangerctl/main.go
+++ b/cmd/rangerctl/main.go
@@ -146,8 +146,8 @@ func main() {
 		cmdSplit(*printReq, client, ctx, rID, boundary, flag.Arg(3), flag.Arg(4))
 
 	case "join", "j":
-		if flag.NArg() != 4 {
-			fmt.Fprintf(w, "Usage: %s join <rangeID> <rangeID> <nodeID>\n", os.Args[0])
+		if flag.NArg() < 3 || flag.NArg() > 4 {
+			fmt.Fprintf(w, "Usage: %s join <rangeID> <rangeID> [<nodeID>]\n", os.Args[0])
 			os.Exit(1)
 		}
 

--- a/cmd/rangerctl/main.go
+++ b/cmd/rangerctl/main.go
@@ -28,7 +28,7 @@ func main() {
 		fmt.Fprintf(w, "  - nodes\n")
 		fmt.Fprintf(w, "  - node <nodeID>\n")
 		fmt.Fprintf(w, "  - move <rangeID> <nodeID>\n")
-		fmt.Fprintf(w, "  - split <rangeID> <boundary> <nodeID> <nodeID>\n")
+		fmt.Fprintf(w, "  - split <rangeID> <boundary> [<nodeID>] [<nodeID>]\n")
 		fmt.Fprintf(w, "  - join <rangeID> <rangeID> <nodeID>\n")
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "Flags:\n")
@@ -116,8 +116,8 @@ func main() {
 		cmdMove(*printReq, client, ctx, rID, flag.Arg(2))
 
 	case "split", "s":
-		if flag.NArg() != 5 {
-			fmt.Fprintf(w, "Usage: %s split <rangeID> <boundary> <nodeID> <nodeID>\n", os.Args[0])
+		if flag.NArg() < 3 || flag.NArg() > 5 {
+			fmt.Fprintf(w, "Usage: %s split <rangeID> <boundary> [<nodeID>] [<nodeID>]\n", os.Args[0])
 			os.Exit(1)
 		}
 

--- a/pkg/orchestrator/operations.go
+++ b/pkg/orchestrator/operations.go
@@ -15,6 +15,9 @@ type OpMove struct {
 type OpSplit struct {
 	Range ranje.Ident
 	Key   ranje.Key
+	Left  string
+	Right string
+	Err   chan error
 }
 
 // TODO: Allow operator to specify which node to target?

--- a/pkg/orchestrator/operations.go
+++ b/pkg/orchestrator/operations.go
@@ -20,8 +20,9 @@ type OpSplit struct {
 	Err   chan error
 }
 
-// TODO: Allow operator to specify which node to target?
 type OpJoin struct {
 	Left  ranje.Ident
 	Right ranje.Ident
+	Dest  string
+	Err   chan error
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -144,6 +144,7 @@ func (b *Orchestrator) tickRange(r *ranje.Range) {
 
 		}
 
+		// Pending move for this range?
 		if opMove, ok := b.moveOp(r.Meta.Ident); ok {
 			err := b.doMove(r, opMove)
 			if err != nil {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -133,7 +133,7 @@ func (b *Orchestrator) tickRange(r *ranje.Range) {
 		// Not enough placements? Create one!
 		if len(r.Placements) < b.cfg.Replication {
 
-			nID, err := b.rost.Candidate(r, *ranje.AnyNode())
+			nID, err := b.rost.Candidate(r, ranje.AnyNode)
 			if err != nil {
 				log.Printf("error finding candidate node for %v: %v", r, err)
 				return
@@ -141,7 +141,6 @@ func (b *Orchestrator) tickRange(r *ranje.Range) {
 
 			p := ranje.NewPlacement(r, nID)
 			r.Placements = append(r.Placements, p)
-
 		}
 
 		// Pending move for this range?

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -585,7 +585,7 @@ func (ts *OrchestratorSuite) TestSplit() {
 
 	ts.tickWait()
 	ts.Empty(ts.nodes.RPCs())
-	ts.Equal("{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsReady} {2 [-inf, ccc] RsActive} {3 (ccc, +inf] RsActive}", ts.ks.LogString())
+	ts.Equal("{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsReady} {2 [-inf, ccc] RsActive p0=test-aaa:PsPending} {3 (ccc, +inf] RsActive p0=test-aaa:PsPending}", ts.ks.LogString())
 	ts.Equal("{test-aaa [1:NsReady]}", ts.rost.TestString())
 
 	// 2. Controller places new ranges on nodes.

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -571,15 +571,15 @@ func (ts *OrchestratorSuite) TestSplit() {
 
 	// -------------------------------------------------------------------------
 
-	func() {
-		ts.orch.opSplitsMu.Lock()
-		defer ts.orch.opSplitsMu.Unlock()
-		// TODO: Probably add a method to do this.
-		ts.orch.opSplits[r0.Meta.Ident] = OpSplit{
-			Range: r0.Meta.Ident,
-			Key:   "ccc",
-		}
-	}()
+	op := OpSplit{
+		Range: r0.Meta.Ident,
+		Key:   "ccc",
+		Err:   make(chan error),
+	}
+
+	ts.orch.opSplitsMu.Lock()
+	ts.orch.opSplits[r0.Meta.Ident] = op
+	ts.orch.opSplitsMu.Unlock()
 
 	// 1. Split initiated by controller. Node hasn't heard about it yet.
 
@@ -793,6 +793,16 @@ func (ts *OrchestratorSuite) TestSplit() {
 	ts.Equal("{test-aaa [2:NsReady, 3:NsReady]}", ts.rost.TestString())
 
 	ts.EnsureStable()
+
+	// Assert that the error chan was closed, to indicate op is complete.
+	select {
+	case err, ok := <-op.Err:
+		if ok {
+			ts.NoError(err)
+		}
+	default:
+		ts.Fail("expected op.Err to be closed")
+	}
 }
 
 func (ts *OrchestratorSuite) TestJoin() {
@@ -871,21 +881,22 @@ func (ts *OrchestratorSuite) TestJoin() {
 	// TODO: Inject the target node for r3. It currently defaults to the empty
 	//       node
 
-	func() {
-		ts.orch.opJoinsMu.Lock()
-		defer ts.orch.opJoinsMu.Unlock()
+	op := OpJoin{
+		Left:  r1.Meta.Ident,
+		Right: r2.Meta.Ident,
+		Dest:  "test-ccc",
+		Err:   make(chan error),
+	}
 
-		ts.orch.opJoins = append(ts.orch.opJoins, OpJoin{
-			Left:  r1.Meta.Ident,
-			Right: r2.Meta.Ident,
-		})
-	}()
+	ts.orch.opJoinsMu.Lock()
+	ts.orch.opJoins = append(ts.orch.opJoins, op)
+	ts.orch.opJoinsMu.Unlock()
 
 	// 1. Controller initiates join.
 
 	ts.tickWait()
 	ts.Empty(ts.nodes.RPCs())
-	ts.Equal("{1 [-inf, ggg] RsSubsuming p0=test-aaa:PsReady} {2 (ggg, +inf] RsSubsuming p0=test-bbb:PsReady} {3 [-inf, +inf] RsActive}", ts.ks.LogString())
+	ts.Equal("{1 [-inf, ggg] RsSubsuming p0=test-aaa:PsReady} {2 (ggg, +inf] RsSubsuming p0=test-bbb:PsReady} {3 [-inf, +inf] RsActive p0=test-ccc:PsPending}", ts.ks.LogString())
 	ts.Equal("{test-aaa [1:NsReady]} {test-bbb [2:NsReady]} {test-ccc []}", ts.rost.TestString())
 
 	ts.tickWait()
@@ -1028,6 +1039,16 @@ func (ts *OrchestratorSuite) TestJoin() {
 	ts.Equal("{test-aaa []} {test-bbb []} {test-ccc [3:NsReady]}", ts.rost.TestString())
 
 	ts.EnsureStable()
+
+	// Assert that the error chan was closed, to indicate op is complete.
+	select {
+	case err, ok := <-op.Err:
+		if ok {
+			ts.NoError(err)
+		}
+	default:
+		ts.Fail("expected op.Err to be closed")
+	}
 }
 
 func (ts *OrchestratorSuite) TestSlowRPC() {

--- a/pkg/orchestrator/server_orchestrator.go
+++ b/pkg/orchestrator/server_orchestrator.go
@@ -119,6 +119,7 @@ func (bs *orchestratorServer) Join(ctx context.Context, req *pb.JoinRequest) (*p
 		Left:  left,
 		Right: right,
 		Dest:  req.Node,
+		Err:   make(chan error),
 	}
 
 	bs.orch.opJoinsMu.Lock()

--- a/pkg/ranje/constraint.go
+++ b/pkg/ranje/constraint.go
@@ -14,6 +14,5 @@ func (c Constraint) String() string {
 	return "any"
 }
 
-func AnyNode() *Constraint {
-	return &Constraint{}
-}
+// AnyNode is an empty constraint, which matches... any node.
+var AnyNode = Constraint{}

--- a/pkg/roster/roster.go
+++ b/pkg/roster/roster.go
@@ -326,6 +326,14 @@ func (r *Roster) Run(t *time.Ticker) {
 }
 
 // Candidate returns the NodeIdent of a node which could accept the given range.
+//
+// TODO: Instead of an actual range, this should take a "pseudo-range" which is
+//       either a single range (wanting to split) and split point, or two ranges
+//       (wanting to join). Or I guess just a wrapper around a single (moving)
+//       range. From these, we can estimate how much capacity the candidate
+//       node(s) will need, allowing us to find candidates before actually
+//       performing splits and joins.
+//
 func (r *Roster) Candidate(rng *ranje.Range, c ranje.Constraint) (string, error) {
 	r.RLock()
 	defer r.RUnlock()

--- a/pkg/roster/roster.go
+++ b/pkg/roster/roster.go
@@ -2,6 +2,7 @@ package roster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -374,17 +375,32 @@ func (r *Roster) Candidate(rng *ranje.Range, c ranje.Constraint) (string, error)
 	//
 	for i := range nodes {
 		if nodes[i].HasRange(rng.Meta.Ident) {
-			log.Printf("node already has range (nID=%v)", nodes[i].Ident())
+			s := fmt.Sprintf("node already has range: %v", c.NodeID)
+			if c.NodeID != "" {
+				return "", errors.New(s)
+			}
+
+			log.Print(s)
 			continue
 		}
 
 		if nodes[i].WantDrain() {
-			log.Printf("node wants drain (nID=%v)", nodes[i].Ident())
+			s := fmt.Sprintf("node wants drain: %v", nodes[i].Ident())
+			if c.NodeID != "" {
+				return "", errors.New(s)
+			}
+
+			log.Print(s)
 			continue
 		}
 
 		if nodes[i].IsMissing(r.cfg, time.Now()) {
-			log.Printf("node is missing (nID=%v)", nodes[i].Ident())
+			s := fmt.Sprintf("node is missing: %v", nodes[i].Ident())
+			if c.NodeID != "" {
+				return "", errors.New(s)
+			}
+
+			log.Print(s)
 			continue
 		}
 

--- a/pkg/roster/roster.go
+++ b/pkg/roster/roster.go
@@ -346,11 +346,19 @@ func (r *Roster) Candidate(rng *ranje.Range, c ranje.Constraint) (string, error)
 	// Filter the list of nodes by name
 	// (We still might exclude it below though)
 	if c.NodeID != "" {
+		found := false
+
 		for i := range nodes {
 			if nodes[i].Ident() == c.NodeID {
 				nodes = []*Node{nodes[i]}
+				found = true
 				break
 			}
+		}
+
+		// Specific NodeID was given, but no such node was found.
+		if !found {
+			return "", fmt.Errorf("no such node: %v", c.NodeID)
 		}
 	}
 

--- a/pkg/roster/roster.go
+++ b/pkg/roster/roster.go
@@ -374,7 +374,7 @@ func (r *Roster) Candidate(rng *ranje.Range, c ranje.Constraint) (string, error)
 	//    still come back, but let's avoid it anyway.
 	//
 	for i := range nodes {
-		if nodes[i].HasRange(rng.Meta.Ident) {
+		if rng != nil && nodes[i].HasRange(rng.Meta.Ident) {
 			s := fmt.Sprintf("node already has range: %v", c.NodeID)
 			if c.NodeID != "" {
 				return "", errors.New(s)

--- a/pkg/roster/roster_test.go
+++ b/pkg/roster/roster_test.go
@@ -58,7 +58,7 @@ func (ts *RosterSuite) Init() {
 func (ts *RosterSuite) TestNoCandidates() {
 	ts.Init()
 
-	nID, err := ts.rost.Candidate(ts.r, *ranje.AnyNode())
+	nID, err := ts.rost.Candidate(ts.r, ranje.AnyNode)
 	if ts.Error(err) {
 		ts.Equal(fmt.Errorf("no candidates available (rID=1, c=any)"), err)
 	}

--- a/pkg/roster/roster_test.go
+++ b/pkg/roster/roster_test.go
@@ -96,6 +96,12 @@ func (ts *RosterSuite) TestCandidateByNodeID() {
 	if ts.NoError(err) {
 		ts.Equal(nID, "test-ccc")
 	}
+
+	// This one doesn't exist
+	nID, err = ts.rost.Candidate(ts.r, ranje.Constraint{NodeID: "test-ddd"})
+	if ts.Error(err) {
+		ts.Equal(err.Error(), "no such node: test-ddd")
+	}
 }
 
 func (ts *RosterSuite) TestProbeOne() {

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -361,3 +361,7 @@ func (n *TestNode) RPCs() []interface{} {
 
 	return ret
 }
+
+func (n *TestNode) SetWantDrain(b bool) {
+	n.rglt.SetWantDrain(b)
+}


### PR DESCRIPTION
I'm improving this gRPC interface in order that an external balancer might use it to move things around. Whether or not that's a good idea, I don't know. But it also makes the operator experience a lot nicer when using the client.

Changes:
- Allow destination nodes of split/join placements to be specified
- Block split/join RPCs until the operation is complete
- Improve candidate selection by returning specific errors when a node ID is specified, rather than "no candidates"
- Make destination nodes optional in rangerctl client (they were mandatory but didn't do anything)

I added a few tests, but not really enough.
To test with empty keyspace, run (in windows/tabs):

```
while true; do clear ; ./rangerctl ranges; sleep 0.5; done
cd examples/kv; bin/dev.sh
cd examples/kv/tools/hammer; go build; ./hammer -addr localhost:5100
```

Now move some ranges around!

```
./rangerctl move 1
./rangerctl split 1 xx
./rangerctl join 2 3
./rangerctl split 4 yy
./rangerctl split 5 gg
./rangerctl move 6
```

(Need to make another hammer to do this move/split/join chaos automatically.)