### PR TITLE
Add many Rangelet tests, fix discovered bugs

### DIFF
--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -8,30 +8,30 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/adammck/ranger/pkg/rangelet"
+	"github.com/adammck/ranger/pkg/api"
 	"github.com/adammck/ranger/pkg/ranje"
 )
 
-func (n *Node) GetLoadInfo(rID ranje.Ident) (rangelet.LoadInfo, error) {
+func (n *Node) GetLoadInfo(rID ranje.Ident) (api.LoadInfo, error) {
 	n.rangesMu.RLock()
 	defer n.rangesMu.RUnlock()
 
 	r, ok := n.ranges[rID]
 	if !ok {
-		return rangelet.LoadInfo{}, rangelet.NotFound
+		return api.LoadInfo{}, api.NotFound
 	}
 
 	r.dataMu.RLock()
 	defer r.dataMu.RUnlock()
 	keys := len(r.data)
 
-	return rangelet.LoadInfo{
+	return api.LoadInfo{
 		Keys: keys,
 	}, nil
 }
 
 // PrepareAddRange: Create the range, but don't do anything with it yet.
-func (n *Node) PrepareAddRange(rm ranje.Meta, parents []rangelet.Parent) error {
+func (n *Node) PrepareAddRange(rm ranje.Meta, parents []api.Parent) error {
 	if err := n.performChaos(); err != nil {
 		return err
 	}

--- a/examples/kv/pkg/node/fetcher.go
+++ b/examples/kv/pkg/node/fetcher.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	pbkv "github.com/adammck/ranger/examples/kv/proto/gen"
-	"github.com/adammck/ranger/pkg/rangelet"
+	"github.com/adammck/ranger/pkg/api"
 	"github.com/adammck/ranger/pkg/ranje"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -23,7 +23,7 @@ type fetcher struct {
 	srcs []src
 }
 
-func newFetcher(rm ranje.Meta, parents []rangelet.Parent) *fetcher {
+func newFetcher(rm ranje.Meta, parents []api.Parent) *fetcher {
 	srcs := []src{}
 
 	// If this is a range move, we can just fetch the whole thing from a single

--- a/examples/kv/pkg/node/node.go
+++ b/examples/kv/pkg/node/node.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	pbkv "github.com/adammck/ranger/examples/kv/proto/gen"
+	"github.com/adammck/ranger/pkg/api"
 	"github.com/adammck/ranger/pkg/config"
 	"github.com/adammck/ranger/pkg/discovery"
 	consuldisc "github.com/adammck/ranger/pkg/discovery/consul"
@@ -47,7 +48,7 @@ type Node struct {
 func init() {
 	// Ensure that nodeServer implements the NodeServer interface
 	var ns *Node = nil
-	var _ rangelet.Node = ns
+	var _ api.Node = ns
 }
 
 func New(cfg config.Config, addrLis, addrPub string, logReqs bool) (*Node, error) {

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -1,34 +1,10 @@
-package rangelet
+package api
 
 import (
 	"errors"
 
 	"github.com/adammck/ranger/pkg/ranje"
-	"github.com/adammck/ranger/pkg/roster/info"
 )
-
-type Placement struct {
-	Node  string
-	State ranje.PlacementState
-}
-
-type Parent struct {
-	Meta       ranje.Meta
-	Parents    []ranje.Ident
-	Placements []Placement
-}
-
-// Same as roster/info.LoadInfo, to avoid circular import.
-type LoadInfo struct {
-	Keys int
-}
-
-type Storage interface {
-	// TODO: Return a rangelet-only type, to avoid importing the whole roster.
-	// TODO: Return info.RangeInfo instead! Pointer is pointless.
-	Read() []*info.RangeInfo
-	Write()
-}
 
 var NotFound = errors.New("EOF")
 

--- a/pkg/api/storage.go
+++ b/pkg/api/storage.go
@@ -1,0 +1,10 @@
+package api
+
+import (
+	"github.com/adammck/ranger/pkg/roster/info"
+)
+
+type Storage interface {
+	Read() []*info.RangeInfo
+	Write()
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"github.com/adammck/ranger/pkg/ranje"
+)
+
+type Placement struct {
+	Node  string
+	State ranje.PlacementState
+}
+
+type Parent struct {
+	Meta       ranje.Meta
+	Parents    []ranje.Ident
+	Placements []Placement
+}
+
+// Same as roster/info.LoadInfo, to avoid circular import.
+type LoadInfo struct {
+	Keys int
+}

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -342,3 +342,9 @@ func withTimeout(timeout time.Duration, f func()) bool {
 		return false
 	}
 }
+
+// Just for tests.
+// TODO: Remove this somehow? Only TestNodes needs it.
+func (r *Rangelet) SetGracePeriod(d time.Duration) {
+	r.gracePeriod = d
+}

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -83,8 +83,7 @@ func (r *Rangelet) runThenUpdateState(rID ranje.Ident, success state.RemoteState
 
 	ri, ok := r.info[rID]
 	if !ok {
-		// The range has vanished from the map??
-		panic("this should not happen!")
+		panic(fmt.Sprintf("range vanished in runThenUpdateState! (rID=%v, s=%s)", rID, s))
 	}
 
 	log.Printf("state is now %v (rID=%v)", s, rID)

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -177,13 +177,13 @@ func (r *Rangelet) serve(rID ranje.Ident) (info.RangeInfo, error) {
 	return *ri, nil
 }
 
-func (r *Rangelet) take(rID ranje.Ident) (*info.RangeInfo, error) {
+func (r *Rangelet) take(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Lock()
 	defer r.Unlock()
 
 	ri, ok := r.info[rID]
 	if !ok {
-		return nil, status.Errorf(codes.InvalidArgument, "can't Take unknown range: %v", rID)
+		return info.RangeInfo{}, status.Errorf(codes.InvalidArgument, "can't Take unknown range: %v", rID)
 	}
 
 	switch ri.State {
@@ -197,20 +197,20 @@ func (r *Rangelet) take(rID ranje.Ident) (*info.RangeInfo, error) {
 		log.Printf("got redundant Take")
 
 	default:
-		return nil, status.Errorf(codes.InvalidArgument, "invalid state for Take: %v", ri.State)
+		return info.RangeInfo{}, status.Errorf(codes.InvalidArgument, "invalid state for Take: %v", ri.State)
 	}
 
-	return ri, nil
+	return *ri, nil
 }
 
-func (r *Rangelet) drop(rID ranje.Ident) (*info.RangeInfo, error) {
+func (r *Rangelet) drop(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Lock()
 	defer r.Unlock()
 
 	ri, ok := r.info[rID]
 	if !ok {
 		log.Printf("got redundant Drop (no such range; maybe drop complete)")
-		return ri, ErrNotFound
+		return info.RangeInfo{}, ErrNotFound
 	}
 
 	switch ri.State {
@@ -224,10 +224,10 @@ func (r *Rangelet) drop(rID ranje.Ident) (*info.RangeInfo, error) {
 		log.Printf("got redundant Drop (drop in progress)")
 
 	default:
-		return nil, status.Errorf(codes.InvalidArgument, "invalid state for Drop: %v", ri.State)
+		return info.RangeInfo{}, status.Errorf(codes.InvalidArgument, "invalid state for Drop: %v", ri.State)
 	}
 
-	return ri, nil
+	return *ri, nil
 }
 
 func (r *Rangelet) Find(k ranje.Key) (ranje.Ident, bool) {

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -41,8 +41,11 @@ func NewRangelet(n api.Node, sr grpc.ServiceRegistrar, s api.Storage) *Rangelet 
 		r.info[ri.Meta.Ident] = ri
 	}
 
-	r.srv = NewNodeServer(r)
-	r.srv.Register(sr)
+	// Can't think of any reason this would be useful outside of a test.
+	if sr != nil {
+		r.srv = NewNodeServer(r)
+		r.srv.Register(sr)
+	}
 
 	return r
 }

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -1,38 +1,190 @@
 package rangelet
 
 import (
-	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/adammck/ranger/pkg/api"
 	"github.com/adammck/ranger/pkg/ranje"
+	"github.com/adammck/ranger/pkg/roster/info"
+	"github.com/adammck/ranger/pkg/roster/state"
 	"github.com/adammck/ranger/pkg/test/fake_node"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
 )
 
-func Setup() (*Rangelet, func()) {
-	stor := fake_node.NewStorage(nil)
-	n := fake_node.NewTestNode("nothing:8000", stor)
-	srv := grpc.NewServer()
-	rglt := NewRangelet(n, srv, stor)
-	closer := n.Listen(context.Background(), srv)
-	return rglt, closer
+type MockNode struct {
+	rGive  error
+	rServe error
+	rTake  error
+	rDrop  error
 }
 
-func TestGive(t *testing.T) {
-	r, closer := Setup()
-	defer closer()
+func (n *MockNode) PrepareAddRange(m ranje.Meta, p []api.Parent) error {
+	return n.rGive
+}
 
-	m := ranje.Meta{
-		Ident: 1,
-		Start: ranje.ZeroKey,
-	}
+func (n *MockNode) AddRange(rID ranje.Ident) error {
+	return n.rServe
+}
 
+func (n *MockNode) PrepareDropRange(rID ranje.Ident) error {
+	return n.rTake
+}
+
+func (n *MockNode) DropRange(rID ranje.Ident) error {
+	return n.rDrop
+}
+
+func Setup() (*MockNode, *Rangelet) {
+	n := &MockNode{}
+	stor := fake_node.NewStorage(nil)
+	rglt := NewRangelet(n, nil, stor)
+	return n, rglt
+}
+
+func TestGiveError(t *testing.T) {
+	n, r := Setup()
+	n.rGive = errors.New("error from PrepareAddRange")
+
+	m := ranje.Meta{Ident: 1}
 	p := []api.Parent{}
 
-	_, err := r.give(m, p)
+	// Give the range. Even though the client will return error from
+	// PrepareAddRange, this will succeed because we call that method in the
+	// background for now. The controller only learns about the failure (or
+	// success!) next time it gives or probes.
+	ri, err := r.give(m, p)
 	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsPreparing, ri.State)
+	}
 
+	// This is just to give the background goroutine (which actually calls
+	// PrepareAddRange) plenty of time to do its thing. Oh dear.
+	//
+	// TODO: Remove this! Change the rangelet to wait for a bit before
+	//       backgrounding the PrepareAddRange (and everything else) so the
+	//       simple/fast case can be synchronous.
+	time.Sleep(10 * time.Millisecond)
+
+	// Send the same request again.
+	ri, err = r.give(m, p)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsPreparingError, ri.State)
+	}
+}
+
+func TestGiveSuccess(t *testing.T) {
+	_, r := Setup()
+
+	m := ranje.Meta{Ident: 1}
+	p := []api.Parent{}
+
+	ri, err := r.give(m, p)
+	if assert.NoError(t, err) {
+		assert.Equal(t, ri.Meta, m)
+		assert.Equal(t, ri.State, state.NsPreparing)
+	}
+
+	// TODO: Noooo
+	time.Sleep(10 * time.Millisecond)
+
+	// Send the same request again.
+	ri, err = r.give(m, p)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsPrepared, ri.State)
+	}
+}
+
+func TestServe(t *testing.T) {
+	_, r := Setup()
+
+	m := ranje.Meta{Ident: 1}
+
+	ri, err := r.serve(m.Ident)
+	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = can't Serve unknown range: 1")
+
+	// correct state to become ready.
+	r.info[m.Ident] = &info.RangeInfo{
+		Meta:  m,
+		State: state.NsPrepared,
+	}
+
+	ri, err = r.serve(m.Ident)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsReadying, ri.State)
+	}
+
+	// TODO: Noooo
+	time.Sleep(10 * time.Millisecond)
+
+	ri, err = r.serve(m.Ident)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsReady, ri.State)
+	}
+}
+
+func TestTake(t *testing.T) {
+	_, r := Setup()
+
+	m := ranje.Meta{Ident: 1}
+
+	ri, err := r.take(m.Ident)
+	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = can't Take unknown range: 1")
+
+	// correct state to be taken.
+	r.info[m.Ident] = &info.RangeInfo{
+		Meta:  m,
+		State: state.NsReady,
+	}
+
+	ri, err = r.take(m.Ident)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsTaking, ri.State)
+	}
+
+	// TODO: Noooo
+	time.Sleep(10 * time.Millisecond)
+
+	ri, err = r.take(m.Ident)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsTaken, ri.State)
+	}
+}
+
+func TestDrop(t *testing.T) {
+	_, r := Setup()
+
+	m := ranje.Meta{Ident: 1}
+
+	ri, err := r.drop(m.Ident)
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// correct state to be dropn.
+	r.info[m.Ident] = &info.RangeInfo{
+		Meta:  m,
+		State: state.NsTaken,
+	}
+
+	ri, err = r.drop(m.Ident)
+	if assert.NoError(t, err) {
+		assert.Equal(t, m, ri.Meta)
+		assert.Equal(t, state.NsDropping, ri.State)
+	}
+
+	// TODO: Noooo
+	time.Sleep(10 * time.Millisecond)
+
+	ri, err = r.drop(m.Ident)
+	if assert.ErrorIs(t, err, ErrNotFound) {
+		// The range was successfully deleted.
+		assert.NotContains(t, r.info, m.Ident)
 	}
 }

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/adammck/ranger/pkg/ranje"
 	"github.com/adammck/ranger/pkg/roster/info"
 	"github.com/adammck/ranger/pkg/roster/state"
-	"github.com/adammck/ranger/pkg/test/fake_node"
+	"github.com/adammck/ranger/pkg/test/fake_storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,9 +46,13 @@ func (n *MockNode) DropRange(rID ranje.Ident) error {
 	return n.rDrop
 }
 
+func (n *MockNode) GetLoadInfo(rID ranje.Ident) (api.LoadInfo, error) {
+	return api.LoadInfo{}, errors.New("not implemented")
+}
+
 func Setup() (*MockNode, *Rangelet) {
 	n := &MockNode{}
-	stor := fake_node.NewStorage(nil)
+	stor := fake_storage.NewFakeStorage(nil)
 	rglt := NewRangelet(n, nil, stor)
 	rglt.gracePeriod = 10 * time.Millisecond
 	return n, rglt

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -113,16 +113,10 @@ func TestGiveErrorFast(t *testing.T) {
 	assert.Equal(t, m, ri.Meta)
 	assert.Equal(t, state.NsPreparingError, ri.State)
 
-	// TODO: Remove this! It's totally wrong!
+	// Check that no range was created.
 	ri, ok := rglt.rangeInfo(m.Ident)
-	require.True(t, ok)
-	assert.Equal(t, state.NsPreparingError, ri.State)
-
-	// TODO: This is how it should work!
-	// // Check that no range was created.
-	// ri, ok := rglt.rangeInfo(m.Ident)
-	// assert.False(t, ok)
-	// assert.Equal(t, info.RangeInfo{}, ri)
+	assert.False(t, ok)
+	assert.Equal(t, info.RangeInfo{}, ri)
 }
 
 func TestGiveErrorSlow(t *testing.T) {
@@ -151,10 +145,10 @@ func TestGiveErrorSlow(t *testing.T) {
 	// Unblock PrepareAddRange.
 	n.wgPrepareAddRange.Done()
 
-	// Wait until PreparingError (because PrepareAddRange returned error)
+	// Wait until range vanishes (because PrepareAddRange returned error)
 	require.Eventually(t, func() bool {
-		ri, ok := rglt.rangeInfo(m.Ident)
-		return ok && ri.State == state.NsPreparingError
+		_, ok := rglt.rangeInfo(m.Ident)
+		return !ok
 	}, waitFor, tick)
 
 	for i := 0; i < 2; i++ {

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -1,0 +1,38 @@
+package rangelet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/adammck/ranger/pkg/api"
+	"github.com/adammck/ranger/pkg/ranje"
+	"github.com/adammck/ranger/pkg/test/fake_node"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func Setup() (*Rangelet, func()) {
+	stor := fake_node.NewStorage(nil)
+	n := fake_node.NewTestNode("nothing:8000", stor)
+	srv := grpc.NewServer()
+	rglt := NewRangelet(n, srv, stor)
+	closer := n.Listen(context.Background(), srv)
+	return rglt, closer
+}
+
+func TestGive(t *testing.T) {
+	r, closer := Setup()
+	defer closer()
+
+	m := ranje.Meta{
+		Ident: 1,
+		Start: ranje.ZeroKey,
+	}
+
+	p := []api.Parent{}
+
+	_, err := r.give(m, p)
+	if assert.NoError(t, err) {
+
+	}
+}

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -165,16 +165,18 @@ func TestGiveErrorSlow(t *testing.T) {
 	}
 }
 
+func setupServe(infos map[ranje.Ident]*info.RangeInfo, m ranje.Meta) {
+	infos[m.Ident] = &info.RangeInfo{
+		Meta:  m,
+		State: state.NsPrepared,
+	}
+}
+
 func TestServeFast(t *testing.T) {
 	_, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for AddRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsPrepared,
-	}
+	setupServe(rglt.info, m)
 
 	ri, err := rglt.serve(m.Ident)
 	require.NoError(t, err)
@@ -197,12 +199,7 @@ func TestServeSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for AddRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsPrepared,
-	}
+	setupServe(rglt.info, m)
 
 	// AddRange will take a long time!
 	n.wgAddRange.Add(1)
@@ -245,15 +242,11 @@ func TestServeUnknown(t *testing.T) {
 
 func TestServeErrorFast(t *testing.T) {
 	n, rglt := Setup()
-	n.erAddRange = errors.New("error from AddRange")
 
 	m := ranje.Meta{Ident: 1}
+	setupServe(rglt.info, m)
 
-	// State valid for AddRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsPrepared,
-	}
+	n.erAddRange = errors.New("error from AddRange")
 
 	ri, err := rglt.serve(m.Ident)
 	require.NoError(t, err)
@@ -270,12 +263,7 @@ func TestServeErrorSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for AddRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsPrepared,
-	}
+	setupServe(rglt.info, m)
 
 	// AddRange will block, then return an error.
 	n.erAddRange = errors.New("error from AddRange")
@@ -308,16 +296,18 @@ func TestServeErrorSlow(t *testing.T) {
 	}
 }
 
+func setupTake(infos map[ranje.Ident]*info.RangeInfo, m ranje.Meta) {
+	infos[m.Ident] = &info.RangeInfo{
+		Meta:  m,
+		State: state.NsReady,
+	}
+}
+
 func TestTakeFast(t *testing.T) {
 	_, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for PrepareDropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsReady,
-	}
+	setupTake(rglt.info, m)
 
 	ri, err := rglt.take(m.Ident)
 	require.NoError(t, err)
@@ -340,12 +330,7 @@ func TestTakeSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for PrepareDropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsReady,
-	}
+	setupTake(rglt.info, m)
 
 	n.wgPrepareDropRange.Add(1)
 
@@ -390,15 +375,11 @@ func TestTakeUnknown(t *testing.T) {
 
 func TestTakeErrorFast(t *testing.T) {
 	n, rglt := Setup()
-	n.erPrepareDropRange = errors.New("error from PrepareDropRange")
 
 	m := ranje.Meta{Ident: 1}
+	setupTake(rglt.info, m)
 
-	// State valid for PrepareDropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsReady,
-	}
+	n.erPrepareDropRange = errors.New("error from PrepareDropRange")
 
 	ri, err := rglt.take(m.Ident)
 	require.NoError(t, err)
@@ -415,12 +396,7 @@ func TestTakeErrorSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for PrepareDropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsReady,
-	}
+	setupTake(rglt.info, m)
 
 	// PrepareDropRange will block, then return an error.
 	n.erPrepareDropRange = errors.New("error from PrepareDropRange")
@@ -453,16 +429,18 @@ func TestTakeErrorSlow(t *testing.T) {
 	}
 }
 
+func setupDrop(infos map[ranje.Ident]*info.RangeInfo, m ranje.Meta) {
+	infos[m.Ident] = &info.RangeInfo{
+		Meta:  m,
+		State: state.NsTaken,
+	}
+}
+
 func TestDropFast(t *testing.T) {
 	_, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for DropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsTaken,
-	}
+	setupDrop(rglt.info, m)
 
 	ri, err := rglt.drop(m.Ident)
 	require.NoError(t, err)
@@ -483,12 +461,7 @@ func TestDropSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for DropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsTaken,
-	}
+	setupDrop(rglt.info, m)
 
 	// DropRange will block.
 	n.wgDropRange.Add(1)
@@ -524,7 +497,6 @@ func TestDropUnknown(t *testing.T) {
 	_, rglt := Setup()
 
 	ri, err := rglt.drop(1)
-
 	require.NoError(t, err)
 	assert.Equal(t,
 		info.RangeInfo{
@@ -535,15 +507,11 @@ func TestDropUnknown(t *testing.T) {
 
 func TestDropErrorFast(t *testing.T) {
 	n, rglt := Setup()
-	n.erDropRange = errors.New("error from DropRange")
 
 	m := ranje.Meta{Ident: 1}
+	setupDrop(rglt.info, m)
 
-	// State valid for DropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsTaken,
-	}
+	n.erDropRange = errors.New("error from DropRange")
 
 	ri, err := rglt.drop(m.Ident)
 	require.NoError(t, err)
@@ -560,12 +528,7 @@ func TestDropErrorSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := ranje.Meta{Ident: 1}
-
-	// State valid for DropRange.
-	rglt.info[m.Ident] = &info.RangeInfo{
-		Meta:  m,
-		State: state.NsTaken,
-	}
+	setupDrop(rglt.info, m)
 
 	// DropRange will block, then return an error.
 	n.erDropRange = errors.New("error from DropRange")

--- a/pkg/rangelet/server.go
+++ b/pkg/rangelet/server.go
@@ -3,6 +3,7 @@ package rangelet
 import (
 	"context"
 
+	"github.com/adammck/ranger/pkg/api"
 	pb "github.com/adammck/ranger/pkg/proto/gen"
 	"github.com/adammck/ranger/pkg/ranje"
 	"github.com/adammck/ranger/pkg/roster/info"
@@ -26,8 +27,8 @@ func (ns *NodeServer) Register(sr grpc.ServiceRegistrar) {
 	pb.RegisterNodeServer(sr, ns)
 }
 
-func parentsFromProto(prot []*pb.Parent) ([]Parent, error) {
-	p := []Parent{}
+func parentsFromProto(prot []*pb.Parent) ([]api.Parent, error) {
+	p := []api.Parent{}
 
 	for _, pp := range prot {
 		m, err := ranje.MetaFromProto(pp.Range)
@@ -40,15 +41,15 @@ func parentsFromProto(prot []*pb.Parent) ([]Parent, error) {
 			parentIds[i] = ranje.Ident(pp.Parent[i])
 		}
 
-		placements := make([]Placement, len(pp.Placements))
+		placements := make([]api.Placement, len(pp.Placements))
 		for i := range pp.Placements {
-			placements[i] = Placement{
+			placements[i] = api.Placement{
 				Node:  pp.Placements[i].Node,
 				State: ranje.PlacementStateFromProto(&pp.Placements[i].State),
 			}
 		}
 
-		p = append(p, Parent{
+		p = append(p, api.Parent{
 			Meta:       *m,
 			Parents:    parentIds,
 			Placements: placements,

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/adammck/ranger/pkg/ranje"
 	"github.com/adammck/ranger/pkg/roster/info"
 	"github.com/adammck/ranger/pkg/roster/state"
+	"github.com/adammck/ranger/pkg/test/fake_storage"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )
@@ -65,8 +66,12 @@ func NewTestNode(ctx context.Context, addr string, rangeInfos map[ranje.Ident]*i
 	}
 
 	srv := grpc.NewServer()
-	stor := NewStorage(rangeInfos)
+	stor := fake_storage.NewFakeStorage(rangeInfos)
 	n.rglt = rangelet.NewRangelet(n, srv, stor)
+
+	// Just for tests.
+	n.rglt.SetGracePeriod(10 * time.Millisecond)
+
 	closer := n.Listen(ctx, srv)
 
 	return n, closer

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adammck/ranger/pkg/api"
 	pb "github.com/adammck/ranger/pkg/proto/gen"
 	"github.com/adammck/ranger/pkg/rangelet"
 	"github.com/adammck/ranger/pkg/ranje"
@@ -29,7 +30,7 @@ type TestNode struct {
 	Conn *grpc.ClientConn
 	rglt *rangelet.Rangelet
 
-	loadInfos map[ranje.Ident]rangelet.LoadInfo
+	loadInfos map[ranje.Ident]api.LoadInfo
 
 	// Keep requests sent to this node.
 	// Call RPCs() to fetch and clear.
@@ -59,9 +60,9 @@ func NewTestNode(ctx context.Context, addr string, rangeInfos map[ranje.Ident]*i
 
 	// Extract LoadInfos to keep in the client (TestNode). Rangelet fetches via
 	// GetLoadInfo.
-	li := map[ranje.Ident]rangelet.LoadInfo{}
+	li := map[ranje.Ident]api.LoadInfo{}
 	for _, ri := range rangeInfos {
-		li[ri.Meta.Ident] = rangelet.LoadInfo{
+		li[ri.Meta.Ident] = api.LoadInfo{
 			Keys: int(ri.Info.Keys),
 		}
 	}
@@ -121,16 +122,16 @@ func (n *TestNode) waitUntil(rID ranje.Ident, src state.RemoteState) error {
 	}
 }
 
-func (n *TestNode) GetLoadInfo(rID ranje.Ident) (rangelet.LoadInfo, error) {
+func (n *TestNode) GetLoadInfo(rID ranje.Ident) (api.LoadInfo, error) {
 	li, ok := n.loadInfos[rID]
 	if !ok {
-		return rangelet.LoadInfo{}, rangelet.NotFound
+		return api.LoadInfo{}, api.NotFound
 	}
 
 	return li, nil
 }
 
-func (n *TestNode) PrepareAddRange(m ranje.Meta, p []rangelet.Parent) error {
+func (n *TestNode) PrepareAddRange(m ranje.Meta, p []api.Parent) error {
 	return n.waitUntil(m.Ident, state.NsPreparing)
 }
 

--- a/pkg/test/fake_node/storage.go
+++ b/pkg/test/fake_node/storage.go
@@ -1,14 +1,26 @@
 package fake_node
 
-import "github.com/adammck/ranger/pkg/roster/info"
+import (
+	"github.com/adammck/ranger/pkg/ranje"
+	"github.com/adammck/ranger/pkg/roster/info"
+)
 
-type Storage struct {
+type storage struct {
 	infos []*info.RangeInfo
 }
 
-func (s *Storage) Read() []*info.RangeInfo {
+func NewStorage(rangeInfos map[ranje.Ident]*info.RangeInfo) *storage {
+	infos := []*info.RangeInfo{}
+	for _, ri := range rangeInfos {
+		infos = append(infos, ri)
+	}
+
+	return &storage{infos}
+}
+
+func (s *storage) Read() []*info.RangeInfo {
 	return s.infos
 }
 
-func (s *Storage) Write() {
+func (s *storage) Write() {
 }

--- a/pkg/test/fake_nodes/fake_nodes.go
+++ b/pkg/test/fake_nodes/fake_nodes.go
@@ -36,8 +36,8 @@ func (tn *TestNodes) Close() {
 
 func (tn *TestNodes) Add(ctx context.Context, remote discovery.Remote, rangeInfos map[ranje.Ident]*info.RangeInfo) {
 	n, closer := fake_node.NewTestNode(ctx, remote.Addr(), rangeInfos)
-	tn.nodes[remote.Ident] = n
 	tn.closers = append(tn.closers, closer)
+	tn.nodes[remote.Ident] = n
 	tn.disc.Add("node", remote)
 }
 
@@ -68,6 +68,12 @@ func (tn *TestNodes) RPCs() map[string][]interface{} {
 func (tn *TestNodes) NodeConnFactory(ctx context.Context, remote discovery.Remote) (*grpc.ClientConn, error) {
 	for _, n := range tn.nodes {
 		if n.Addr == remote.Addr() {
+
+			if n.Conn == nil {
+				// Fail rather than return nil connection
+				return nil, fmt.Errorf("nil conn (called before Listen) for test node: %v", n)
+			}
+
 			return n.Conn, nil
 		}
 	}

--- a/pkg/test/fake_storage/fake_storage.go
+++ b/pkg/test/fake_storage/fake_storage.go
@@ -1,4 +1,4 @@
-package fake_node
+package fake_storage
 
 import (
 	"github.com/adammck/ranger/pkg/ranje"
@@ -9,7 +9,7 @@ type storage struct {
 	infos []*info.RangeInfo
 }
 
-func NewStorage(rangeInfos map[ranje.Ident]*info.RangeInfo) *storage {
+func NewFakeStorage(rangeInfos map[ranje.Ident]*info.RangeInfo) *storage {
 	infos := []*info.RangeInfo{}
 	for _, ri := range rangeInfos {
 		infos = append(infos, ri)


### PR DESCRIPTION
This mostly adds tests to the rangelet. But also moves much of the interface to pkg/api (from pkg/rangelet) to avoid circular imports in those tests. Also fixes a rather critical state bug which occurs when PrepareAddRange fails. (The range wasn't cleaned up, so was left in NsPreparingError forever. But the controller discarded its copy of the range, and chose a new candidate to retry placement on. Oops.)