### PR TITLE
Add crappy automatic balancer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # binaries
 __debug_bin
+/cmd/dumbbal/dumbbal
 /cmd/rangerctl/rangerctl
 /cmd/rangerd/rangerd
 /examples/kv/kv

--- a/cmd/dumbbal/main.go
+++ b/cmd/dumbbal/main.go
@@ -116,16 +116,13 @@ func main() {
 		var maxSplit string
 
 		for _, p := range r.placements {
-
-			// Skip placements with no suggested splits.
-			if len(p.info.Splits) == 0 {
-				continue
-			}
-
 			s := p.info.Keys
 			if s > maxScore {
 				maxScore = s
-				maxSplit = p.info.Splits[0]
+
+				if len(p.info.Splits) > 0 {
+					maxSplit = p.info.Splits[0]
+				}
 			}
 		}
 
@@ -136,11 +133,14 @@ func main() {
 		}
 	}
 
-	// -- Find any ranges higher than the threshold, in descending order
+	// -- Find any ranges higher than the threshold, having splits, in descending order
 
 	splits := []int{}
 
 	for i, r := range scores {
+		if r.split == "" {
+			continue
+		}
 		if r.score > *splitScore {
 			splits = append(splits, i)
 		}

--- a/cmd/dumbbal/main.go
+++ b/cmd/dumbbal/main.go
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	// Create a debug client (like rangerctl)
+
+	// Fetch the current state of all the ranges
+
+	// Find any ranges higher than the threshold
+
+	// Send RPCs (in parallel) to split each one
+
+	// Find any adjacent range pairs lower than the threshold
+
+	// Send RPCs (in parallel) to join each pair
+
+	// Exit
+}

--- a/cmd/dumbbal/main.go
+++ b/cmd/dumbbal/main.go
@@ -1,17 +1,245 @@
 package main
 
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	pb "github.com/adammck/ranger/pkg/proto/gen"
+	"google.golang.org/grpc"
+)
+
 func main() {
-	// Create a debug client (like rangerctl)
+	w := flag.CommandLine.Output()
 
-	// Fetch the current state of all the ranges
+	addr := flag.String("addr", "localhost:5000", "controller address")
+	dryRun := flag.Bool("dry-run", false, "just print operations")
+	force := flag.Bool("force", false, "actually run operations")
+	num := flag.Uint("num", 10, "maximum number of operations to perform")
+	splitScore := flag.Uint64("split", 100, "score threshold to split ranges")
+	joinScore := flag.Uint64("join", 20, "score threshold to join adjacent ranges")
+	flag.Parse()
 
-	// Find any ranges higher than the threshold
+	if !*dryRun && !*force {
+		fmt.Fprint(w, "Error: either -dry-run or -force is required\n")
+		os.Exit(1)
+	}
 
-	// Send RPCs (in parallel) to split each one
+	// TODO: Catch signals for cancellation.
+	ctx := context.Background()
 
-	// Find any adjacent range pairs lower than the threshold
+	// -- Create a debug client (like rangerctl)
 
-	// Send RPCs (in parallel) to join each pair
+	ctxDial, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
 
-	// Exit
+	conn, err := grpc.DialContext(ctxDial, *addr, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		fmt.Fprintf(w, "Error dialing controller: %v\n", err)
+		os.Exit(1)
+	}
+
+	client := pb.NewDebugClient(conn)
+
+	// -- Fetch the current state of all the ranges
+
+	ctxRL, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req := &pb.RangesListRequest{}
+
+	res, err := client.RangesList(ctxRL, req)
+
+	if err != nil {
+		fmt.Fprintf(w, "Debug.RangesList returned: %v\n", err)
+		os.Exit(1)
+	}
+
+	// -- Build list of ranges to examine
+
+	type Placement struct {
+		index int
+		info  *pb.LoadInfo
+	}
+
+	type Range struct {
+		rID        uint64
+		placements []Placement
+	}
+
+	ranges := []Range{}
+
+	for _, r := range res.Ranges {
+
+		// Ignore non-active ranges (probably already being split/joined).
+		if r.State != pb.RangeState_RS_ACTIVE {
+			continue
+		}
+
+		placements := []Placement{}
+		for i, p := range r.Placements {
+			if p.Placement.State == pb.PlacementState_PS_READY {
+				placements = append(placements, Placement{
+					index: i,
+					info:  p.RangeInfo.Info,
+				})
+			}
+		}
+
+		// Ignore ranges with no ready placements.
+		if len(placements) == 0 {
+			continue
+		}
+
+		ranges = append(ranges, Range{
+			rID:        r.Meta.Ident,
+			placements: placements,
+		})
+	}
+
+	// -- Score each range
+
+	type RangeWithScore struct {
+		rID   uint64
+		score uint64
+		split string
+	}
+
+	scores := make([]RangeWithScore, len(ranges))
+
+	for i, r := range ranges {
+		var maxScore uint64
+		var maxSplit string
+
+		for _, p := range r.placements {
+			s := p.info.Keys
+			if s > maxScore {
+				maxScore = s
+				maxSplit = p.info.Splits[0]
+			}
+		}
+
+		scores[i] = RangeWithScore{
+			rID:   r.rID,
+			score: maxScore,
+			split: maxSplit,
+		}
+	}
+
+	// -- Find any ranges higher than the threshold, in descending order
+
+	splits := []int{}
+
+	for i, r := range scores {
+		if r.score > *splitScore {
+			splits = append(splits, i)
+		}
+	}
+
+	sort.Slice(splits, func(i, j int) bool {
+		return scores[i].score > scores[j].score
+	})
+
+	// -- Send RPCs (in parallel) to split each one
+
+	var ops uint
+	orchClient := pb.NewOrchestratorClient(conn)
+	ctxSp, cancel := context.WithTimeout(ctx, 30*time.Second)
+	wg := sync.WaitGroup{}
+
+	for _, s := range splits {
+		if *dryRun {
+			fmt.Printf("Would split: range %d (score: %d) at %q\n", scores[s].rID, scores[s].score, scores[s].split)
+			continue
+		}
+		if ops >= *num {
+			continue
+		}
+
+		s := s
+		ops += 1
+		wg.Add(1)
+		go func() {
+			defer cancel()
+
+			req := &pb.SplitRequest{
+				Range:    scores[s].rID,
+				Boundary: []byte(scores[s].split),
+			}
+
+			fmt.Printf("Splitting: range %d (score: %d)\n", scores[s].rID, scores[s].score)
+			_, err := orchClient.Split(ctxSp, req)
+
+			if err != nil {
+				fmt.Printf("Error splitting range %d: %v\n", scores[s].rID, err)
+				wg.Done()
+				return
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	// -- Find any adjacent range pairs lower than the threshold, in ascending order
+
+	joins := []int{}
+
+	for i := 0; i < len(scores)-1; i++ {
+		if scores[i].score+scores[i+1].score < *joinScore {
+			joins = append(joins, i)
+		}
+	}
+
+	sort.Slice(joins, func(i, j int) bool {
+		return (scores[i].score + scores[i+1].score) < (scores[j].score + scores[j+1].score) // uhhh
+	})
+
+	// -- Send RPCs (in parallel) to join each pair
+
+	ctxJo, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+	for _, j := range joins {
+		left := scores[j].rID
+		right := scores[j+1].rID
+		score := scores[j].score + scores[j].score
+		if *dryRun {
+			fmt.Printf("Would join: range %d, range %d (combined score: %d)\n", left, right, score)
+			continue
+		}
+		if ops >= *num {
+			continue
+		}
+
+		ops += 1
+		wg.Add(1)
+		go func() {
+			defer cancel()
+
+			req := &pb.JoinRequest{
+				RangeLeft:  left,
+				RangeRight: right,
+			}
+
+			fmt.Printf("Joining: range %d, range %d (combined score: %d)\n", left, right, score)
+			_, err := orchClient.Join(ctxJo, req)
+
+			if err != nil {
+				fmt.Printf("Error joining ranges %d and %d: %v\n", left, right, err)
+				wg.Done()
+				return
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	// -- Exit
 }

--- a/cmd/dumbbal/main.go
+++ b/cmd/dumbbal/main.go
@@ -116,6 +116,12 @@ func main() {
 		var maxSplit string
 
 		for _, p := range r.placements {
+
+			// Skip placements with no suggested splits.
+			if len(p.info.Splits) == 0 {
+				continue
+			}
+
 			s := p.info.Keys
 			if s > maxScore {
 				maxScore = s

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,5 +17,6 @@ type Parent struct {
 
 // Same as roster/info.LoadInfo, to avoid circular import.
 type LoadInfo struct {
-	Keys int
+	Keys   int
+	Splits []ranje.Key
 }

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -29,9 +29,13 @@ message LoadInfo {
   // Just for reporting? Not balancing?
   uint64 keys = 1;
 
+  // Where the node would suggest that this range be split, in order for the
+  // resulting ranges to be evenly loaded. Otherwise the mid-point between start
+  // and end keys will be used, which is probably not an even split.
+  repeated string splits = 2;
+ 
   // TODO: Generic load info? cpu/ram/network/disk?
   // TODO: Extra domain-specific info?
-  // TODO: Suggested split point(s)
 }
 
 // TODO: Rename to RemoteRangeInfo, since this is the view from the remote.

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -365,6 +365,10 @@ func (r *Rangelet) gatherLoadInfo() error {
 // TODO: Remove once roster/info import is gone from rangelet.
 func updateLoadInfo(rostLI *info.LoadInfo, rgltLI api.LoadInfo) {
 	rostLI.Keys = uint64(rgltLI.Keys)
+	rostLI.Splits = make([]ranje.Key, len(rgltLI.Splits))
+	for i, s := range rgltLI.Splits {
+		rostLI.Splits[i] = s
+	}
 }
 
 func (r *Rangelet) walk(f func(*info.RangeInfo)) {

--- a/pkg/roster/info/info.go
+++ b/pkg/roster/info/info.go
@@ -25,18 +25,31 @@ type NodeInfo struct {
 // TODO: Would be nice to just use a rangelet.LoadInfo here, but circular
 //       import! Remove roster/info import from rangelet, then resolve this.
 type LoadInfo struct {
-	Keys uint64
+	Keys   uint64
+	Splits []ranje.Key
 }
 
 func (li *LoadInfo) ToProto() *pb.LoadInfo {
+	splits := make([]string, len(li.Splits))
+	for i := range li.Splits {
+		splits[i] = string(li.Splits[i])
+	}
+
 	return &pb.LoadInfo{
-		Keys: li.Keys,
+		Keys:   li.Keys,
+		Splits: splits,
 	}
 }
 
 func LoadInfoFromProto(pbli *pb.LoadInfo) LoadInfo {
+	splits := make([]ranje.Key, len(pbli.Splits))
+	for i := range pbli.Splits {
+		splits[i] = ranje.Key(pbli.Splits[i])
+	}
+
 	return LoadInfo{
-		Keys: pbli.Keys,
+		Keys:   pbli.Keys,
+		Splits: splits,
 	}
 }
 


### PR DESCRIPTION
This adds _suggested splits_ to the loadinfo, and plumbs it through everything so that it's returned from the Debug.RangesList rpc. (Not so Debug anymore, I guess.) It also updates the kv example to suggest a split at key in the middle of the keys that it has seen about (not the lexicographical middle of the range), in a very inefficient manner with no caching.

It also adds a janky tool, dumbbal, to fetch the ranges from the controller, score each one, and suggest (optionally send) Split and Join RPCs to keep the total number of keys in each range within a configurable band. It's only balancing by number of keys, not actual load, but works pretty well!

To test manually:

```
bin/gen-proto.sh
examples/kv/bin/gen-proto.sh
```

(protos have changed, still not checked in)
Then in separate tabs:

```
cd examples/kv; bin/dev.sh
cd examples/kv/tools/hammer; go build; ./hammer -addr localhost:5100
cd cmd/dumbbal; go build; ./dumbbal -dry-run
```

To keep things balanced, just run in a loop!

```
while true; do
  ./dumbbal -force
  sleep 5;
done
```
