### PR TITLE
Add more Orchestrator tests

### DIFF
--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -152,12 +152,13 @@ func (n *Node) performChaos() error {
 
 	ms := int(3000 * math.Pow(rand.Float64(), 2))
 	d := time.Duration(ms) * time.Millisecond
-	log.Printf("Sleeping %v", d)
+	log.Printf("Sleeping %v (chaos)", d)
 	time.Sleep(d)
 
 	// TODO: This causes actual problems really fast if raised significantly.
 	//       Looks like an orchestrator bug. Look into it.
 	if rand.Float32() < 0.05 {
+		log.Print("Failing (chaos)")
 		return fmt.Errorf("it's your unlucky day")
 	}
 

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -286,6 +286,7 @@ func (ts *OrchestratorSuite) TestPlacementSlow() {
 
 	par := ts.nodes.Get("test-aaa").Expect(ts.T(), 1, state.NsPreparing, nil)
 	ts.tickWait()
+	par.Wait()
 	if rpcs := ts.nodes.RPCs(); ts.Equal([]string{"test-aaa"}, nIDs(rpcs)) {
 		if aaa := rpcs["test-aaa"]; ts.Len(aaa, 1) {
 			ts.ProtoEqual(&pb.GiveRequest{
@@ -346,6 +347,7 @@ func (ts *OrchestratorSuite) TestPlacementSlow() {
 
 	ar := ts.nodes.Get("test-aaa").Expect(ts.T(), 1, state.NsReadying, nil)
 	ts.tickWait()
+	ar.Wait()
 	ts.Len(RPCs(ts.nodes.RPCs()), 1) // redundant Serve
 	ts.Equal("{1 [-inf, +inf] RsActive p0=test-aaa:PsPrepared}", ts.ks.LogString())
 	ts.Equal("{test-aaa [1:NsReadying]}", ts.rost.TestString())
@@ -721,6 +723,8 @@ func (ts *OrchestratorSuite) TestSplit() {
 	a2PAR := ts.nodes.Get("test-aaa").Expect(ts.T(), 2, state.NsPreparing, nil)
 	a3PAR := ts.nodes.Get("test-aaa").Expect(ts.T(), 3, state.NsPreparing, nil)
 	ts.tickWait()
+	a2PAR.Wait()
+	a3PAR.Wait()
 	if rpcs := ts.nodes.RPCs(); ts.Equal([]string{"test-aaa"}, nIDs(rpcs)) {
 		if aaa := rpcs["test-aaa"]; ts.Len(aaa, 2) {
 			ts.ProtoEqual(&pb.GiveRequest{
@@ -822,6 +826,7 @@ func (ts *OrchestratorSuite) TestSplit() {
 
 	a1PDR := ts.nodes.Get("test-aaa").Expect(ts.T(), 1, state.NsTaking, nil)
 	ts.tickWait()
+	a1PDR.Wait()
 	if rpcs := ts.nodes.RPCs(); ts.Equal([]string{"test-aaa"}, nIDs(rpcs)) {
 		if aaa := rpcs["test-aaa"]; ts.Len(aaa, 1) {
 			ts.ProtoEqual(&pb.TakeRequest{Range: 1}, aaa[0])
@@ -843,6 +848,8 @@ func (ts *OrchestratorSuite) TestSplit() {
 	a2AR := ts.nodes.Get("test-aaa").Expect(ts.T(), 2, state.NsReadying, nil)
 	a3AR := ts.nodes.Get("test-aaa").Expect(ts.T(), 3, state.NsReadying, nil)
 	ts.tickWait()
+	a2AR.Wait()
+	a3AR.Wait()
 	if rpcs := ts.nodes.RPCs(); ts.Equal([]string{"test-aaa"}, nIDs(rpcs)) {
 		if aaa := rpcs["test-aaa"]; ts.Len(aaa, 2) {
 			ts.ProtoEqual(&pb.ServeRequest{Range: 2}, aaa[0])
@@ -880,6 +887,7 @@ func (ts *OrchestratorSuite) TestSplit() {
 
 	a1DR := ts.nodes.Get("test-aaa").Expect(ts.T(), 1, state.NsDropping, nil)
 	ts.tickWait()
+	a1DR.Wait()
 	if rpcs := ts.nodes.RPCs(); ts.Equal([]string{"test-aaa"}, nIDs(rpcs)) {
 		if aaa := rpcs["test-aaa"]; ts.Len(aaa, 1) {
 			ts.ProtoEqual(&pb.DropRequest{Range: 1}, aaa[0])

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -33,8 +33,8 @@ type Rangelet struct {
 
 	srv *NodeServer
 
-	// Holds functions to be called when a specific range enters a state. This
-	// is just for testing. Register callbacks via the OnState method.
+	// Holds functions to be called when a specific range leaves a state. This
+	// is just for testing. Register callbacks via the OnLeaveState method.
 	callbacks map[callback]func()
 }
 
@@ -68,7 +68,7 @@ func NewRangelet(n api.Node, sr grpc.ServiceRegistrar, s api.Storage) *Rangelet 
 
 var ErrNotFound = errors.New("not found")
 
-func (r *Rangelet) runThenUpdateState(rID ranje.Ident, success state.RemoteState, failure state.RemoteState, f func() error) {
+func (r *Rangelet) runThenUpdateState(rID ranje.Ident, old state.RemoteState, success state.RemoteState, failure state.RemoteState, f func() error) {
 	err := f()
 
 	var s state.RemoteState
@@ -87,7 +87,7 @@ func (r *Rangelet) runThenUpdateState(rID ranje.Ident, success state.RemoteState
 	// delete them.
 	if s == state.NsNotFound {
 		delete(r.info, rID)
-		r.runCallback(rID, s)
+		r.runCallback(rID, old, s)
 		log.Printf("range deleted: %v", rID)
 		return
 	}
@@ -96,7 +96,7 @@ func (r *Rangelet) runThenUpdateState(rID ranje.Ident, success state.RemoteState
 	// TODO: Maybe we should keep the range around, for...?
 	if s == state.NsPreparingError {
 		delete(r.info, rID)
-		r.runCallback(rID, s)
+		r.runCallback(rID, old, s)
 		log.Printf("deleting range after failed give: %v", rID)
 		return
 	}
@@ -107,7 +107,7 @@ func (r *Rangelet) runThenUpdateState(rID ranje.Ident, success state.RemoteState
 	}
 
 	ri.State = s
-	r.runCallback(rID, s)
+	r.runCallback(rID, old, s)
 	log.Printf("state is now %v (rID=%v)", s, rID)
 }
 
@@ -143,7 +143,7 @@ func (r *Rangelet) give(rm ranje.Meta, parents []api.Parent) (info.RangeInfo, er
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsPrepared, state.NsPreparingError, func() error {
+		r.runThenUpdateState(rID, state.NsPreparing, state.NsPrepared, state.NsPreparingError, func() error {
 			return r.n.PrepareAddRange(rm, parents)
 		})
 	})
@@ -193,7 +193,7 @@ func (r *Rangelet) serve(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsReady, state.NsReadyingError, func() error {
+		r.runThenUpdateState(rID, state.NsReadying, state.NsReady, state.NsReadyingError, func() error {
 			return r.n.AddRange(rID)
 		})
 	})
@@ -236,7 +236,7 @@ func (r *Rangelet) take(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsTaken, state.NsTakingError, func() error {
+		r.runThenUpdateState(rID, state.NsTaking, state.NsTaken, state.NsTakingError, func() error {
 			return r.n.PrepareDropRange(rID)
 		})
 	})
@@ -282,7 +282,7 @@ func (r *Rangelet) drop(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsNotFound, state.NsDroppingError, func() error {
+		r.runThenUpdateState(rID, state.NsDropping, state.NsNotFound, state.NsDroppingError, func() error {
 			return r.n.DropRange(rID)
 		})
 	})
@@ -410,13 +410,7 @@ func (rglt *Rangelet) State(rID ranje.Ident) state.RemoteState {
 	return r.State
 }
 
-// OnState registers a function which will be called when the given range enters
-// the given state. If the range is already in that state, the func is called
-// immediately and nothing is registered.
-//
-// The function will only be called once, not every time the range enters that
-// state. This should probably only be used for testing.
-func (rglt *Rangelet) OnState(rID ranje.Ident, s state.RemoteState, f func()) {
+func (rglt *Rangelet) OnLeaveState(rID ranje.Ident, s state.RemoteState, f func()) {
 	rglt.Lock()
 	defer rglt.Unlock()
 
@@ -430,8 +424,8 @@ func (rglt *Rangelet) OnState(rID ranje.Ident, s state.RemoteState, f func()) {
 }
 
 // Caller must hold lock.
-func (rglt *Rangelet) runCallback(rID ranje.Ident, s state.RemoteState) {
-	cb := callback{rID: rID, state: s}
+func (rglt *Rangelet) runCallback(rID ranje.Ident, old, new state.RemoteState) {
+	cb := callback{rID: rID, state: old}
 
 	f, ok := rglt.callbacks[cb]
 	if !ok {

--- a/pkg/test/fake_node/barrier.go
+++ b/pkg/test/fake_node/barrier.go
@@ -1,19 +1,22 @@
 package fake_node
 
-import "sync"
+import (
+	"sync"
+)
 
 type barrier struct {
 	arrival *sync.WaitGroup
 	release *sync.WaitGroup
+	cb      func()
 }
 
-func NewBarrier(n int) *barrier {
+func NewBarrier(n int, cb func()) *barrier {
 	a := &sync.WaitGroup{}
 	b := &sync.WaitGroup{}
 	a.Add(n)
 	b.Add(n)
 
-	return &barrier{a, b}
+	return &barrier{a, b, cb}
 }
 
 func (b *barrier) Wait() {
@@ -22,6 +25,7 @@ func (b *barrier) Wait() {
 
 func (b *barrier) Release() {
 	b.release.Done()
+	b.cb()
 }
 
 func (b *barrier) Arrive() {

--- a/pkg/test/fake_node/barrier.go
+++ b/pkg/test/fake_node/barrier.go
@@ -23,6 +23,10 @@ func (b *barrier) Wait() {
 	b.arrival.Wait()
 }
 
+// Release is called in tests to unblock a state transition, which is currently
+// blocked in Arrive. Before returning, as a convenience, it calls the callback
+// (which is probably a WaitGroup on the rangelet changing state) so the caller
+// doesn't have to wait for that itself.
 func (b *barrier) Release() {
 	b.release.Done()
 	b.cb()

--- a/pkg/test/fake_node/barrier.go
+++ b/pkg/test/fake_node/barrier.go
@@ -1,0 +1,30 @@
+package fake_node
+
+import "sync"
+
+type barrier struct {
+	arrival *sync.WaitGroup
+	release *sync.WaitGroup
+}
+
+func NewBarrier(n int) *barrier {
+	a := &sync.WaitGroup{}
+	b := &sync.WaitGroup{}
+	a.Add(n)
+	b.Add(n)
+
+	return &barrier{a, b}
+}
+
+func (b *barrier) Wait() {
+	b.arrival.Wait()
+}
+
+func (b *barrier) Release() {
+	b.release.Done()
+}
+
+func (b *barrier) Arrive() {
+	b.arrival.Done()
+	b.release.Wait()
+}

--- a/pkg/test/fake_nodes/fake_nodes.go
+++ b/pkg/test/fake_nodes/fake_nodes.go
@@ -50,6 +50,12 @@ func (tn *TestNodes) Get(nID string) *fake_node.TestNode {
 	return n
 }
 
+func (tn *TestNodes) SetBlockTransitions(b bool) {
+	for _, n := range tn.nodes {
+		n.SetBlockTransitions(b)
+	}
+}
+
 // RPCs returns a map of NodeID to the (protos) requests which have been
 // received by any node since the last time this method was called.
 func (tn *TestNodes) RPCs() map[string][]interface{} {

--- a/pkg/test/fake_nodes/fake_nodes.go
+++ b/pkg/test/fake_nodes/fake_nodes.go
@@ -50,9 +50,9 @@ func (tn *TestNodes) Get(nID string) *fake_node.TestNode {
 	return n
 }
 
-func (tn *TestNodes) SetBlockTransitions(b bool) {
+func (tn *TestNodes) SetStrictTransitions(b bool) {
 	for _, n := range tn.nodes {
-		n.SetBlockTransitions(b)
+		n.SetStrictTransitions(b)
 	}
 }
 


### PR DESCRIPTION
This doesn't change anything except the test harness, and adds a bunch of Orchestrator tests. The existing extremely verbose tick-by-tick tests are still there, but a second and rather duplicative set of "fast" tests (which might be better described as "short", now that I think about it) skip all the middle steps by (1) setting up the state, (2) ticking until local+remote state stabilizes, (3) asserting the end state.