### PR TITLE
Remove some intermediate remote states

### DIFF
--- a/examples/kv/pkg/proxy/server.go
+++ b/examples/kv/pkg/proxy/server.go
@@ -28,7 +28,7 @@ func (ps *proxyServer) getClient(k string, write bool) (pbkv.KVClient, roster.Lo
 
 	if !write {
 		// Reads are okay while the range is being moved, too.
-		states = append(states, state.NsTaking, state.NsTaken, state.NsTakingError)
+		states = append(states, state.NsTaking, state.NsTaken)
 	}
 
 	locations := ps.proxy.rost.LocateInState(ranje.Key(k), states)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -479,14 +479,6 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement) (destroy bool) {
 				b.ks.PlacementToState(p, ranje.PsPrepared)
 				return
 
-			case state.NsPreparingError:
-				// TODO: Pass back more information from the node, here. It's
-				//       not an RPC error, but there was some failure which we
-				//       can log or handle here.
-				log.Printf("error placing %s on %s", p.Range().Meta.Ident, n.Ident())
-				b.ks.PlacementToState(p, ranje.PsGiveUp)
-				return
-
 			default:
 				log.Printf("very unexpected remote state: %s (placement state=%s)", ri.State, p.State)
 				b.ks.PlacementToState(p, ranje.PsGiveUp)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -614,14 +614,6 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement) (destroy bool) {
 				// the RPC (below) already, so cannot turn back now.
 				log.Printf("node %s still dropping %s", n.Ident(), p.Range().Meta.Ident)
 
-			case state.NsDroppingError:
-				// TODO: Pass back more information from the node, here. It's
-				//       not an RPC error, but there was some failure which we
-				//       can log or handle here.
-				log.Printf("error dropping %s from %s", p.Range().Meta.Ident, n.Ident())
-				b.ks.PlacementToState(p, ranje.PsGiveUp)
-				return
-
 			default:
 				log.Printf("very unexpected remote state: %s (placement state=%s)", ri.State, p.State)
 				b.ks.PlacementToState(p, ranje.PsGiveUp)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -525,13 +525,6 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement) (destroy bool) {
 			// is working on it. Just keep waiting.
 			log.Printf("node %s still readying %s", n.Ident(), p.Range().Meta.Ident)
 
-		case state.NsReadyingError:
-			// TODO: Pass back more information from the node, here. It's
-			//       not an RPC error, but there was some failure which we
-			//       can log or handle here.l
-			log.Printf("error readying %s on %s", p.Range().Meta.Ident, n.Ident())
-			b.ks.PlacementToState(p, ranje.PsGiveUp)
-
 		case state.NsReady:
 			b.ks.PlacementToState(p, ranje.PsReady)
 			return

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -574,14 +574,6 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement) (destroy bool) {
 		case state.NsTaking:
 			log.Printf("node %s still taking %s", n.Ident(), p.Range().Meta.Ident)
 
-		case state.NsTakingError:
-			// TODO: Pass back more information from the node, here. It's
-			//       not an RPC error, but there was some failure which we
-			//       can log or handle here.
-			log.Printf("error taking %s from %s", p.Range().Meta.Ident, n.Ident())
-			b.ks.PlacementToState(p, ranje.PsGiveUp)
-			return
-
 		case state.NsTaken:
 			b.ks.PlacementToState(p, ranje.PsTaken)
 			return

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -61,7 +61,6 @@ enum RangeNodeState {
   PREPARING_ERROR = 2;
   PREPARED = 3;
   READYING = 4;
-  READYING_ERROR = 5;
   READY = 6;
   TAKING = 7;
   TAKEN = 9;

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -65,7 +65,6 @@ enum RangeNodeState {
   TAKING = 7;
   TAKEN = 9;
   DROPPING = 10;
-  DROPPING_ERROR = 11;
   // Special case: See roster.RemoteState
   NOT_FOUND = 12;
 }

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -64,7 +64,6 @@ enum RangeNodeState {
   READYING_ERROR = 5;
   READY = 6;
   TAKING = 7;
-  TAKING_ERROR = 8;
   TAKEN = 9;
   DROPPING = 10;
   DROPPING_ERROR = 11;

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -53,12 +53,11 @@ message RangeInfo {
   LoadInfo info = 3;
  }
 
- // TODO: Rename to RemoteState, like the non-proto type.
+// TODO: Rename to RemoteState, like the non-proto type.
 // Keep synced with RangeState (in node.go for now)
 enum RangeNodeState {
   UNKNOWN = 0;
   PREPARING = 1;
-  PREPARING_ERROR = 2;
   PREPARED = 3;
   READYING = 4;
   READY = 6;

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -58,14 +58,14 @@ message RangeInfo {
 enum RangeNodeState {
   UNKNOWN = 0;
   PREPARING = 1;
-  PREPARED = 3;
-  READYING = 4;
-  READY = 6;
-  TAKING = 7;
-  TAKEN = 9;
-  DROPPING = 10;
+  PREPARED = 2;
+  READYING = 3;
+  READY = 4;
+  TAKING = 5;
+  TAKEN = 6;
+  DROPPING = 7;
   // Special case: See roster.RemoteState
-  NOT_FOUND = 12;
+  NOT_FOUND = 8;
 }
 
 // This is only for debugging purposes, for now.

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -283,11 +283,12 @@ func (r *Rangelet) drop(rID ranje.Ident) (info.RangeInfo, error) {
 
 	// State is NsTaken
 
+	old := ri.State
 	ri.State = state.NsDropping
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsDropping, state.NsNotFound, state.NsDroppingError, func() error {
+		r.runThenUpdateState(rID, state.NsDropping, state.NsNotFound, old, func() error {
 			return r.n.DropRange(rID)
 		})
 	})
@@ -317,7 +318,7 @@ func (r *Rangelet) Find(k ranje.Key) (ranje.Ident, bool) {
 		// before PrepareAddShard has returned, or while DropShard is still in
 		// progress.) The client should check the state anyway, but this makes
 		// the contract simpler.
-		if ri.State == state.NsPreparing || ri.State == state.NsDropping || ri.State == state.NsDroppingError {
+		if ri.State == state.NsPreparing || ri.State == state.NsDropping {
 			continue
 		}
 

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -241,7 +241,7 @@ func (r *Rangelet) take(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsTaking, state.NsTaken, state.NsTakingError, func() error {
+		r.runThenUpdateState(rID, state.NsTaking, state.NsTaken, state.NsReady, func() error {
 			return r.n.PrepareDropRange(rID)
 		})
 	})

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -198,7 +198,7 @@ func (r *Rangelet) serve(rID ranje.Ident) (info.RangeInfo, error) {
 	r.Unlock()
 
 	withTimeout(r.gracePeriod, func() {
-		r.runThenUpdateState(rID, state.NsReadying, state.NsReady, state.NsReadyingError, func() error {
+		r.runThenUpdateState(rID, state.NsReadying, state.NsReady, state.NsPrepared, func() error {
 			return r.n.AddRange(rID)
 		})
 	})

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -111,7 +111,7 @@ func TestGiveErrorFast(t *testing.T) {
 	ri, err := rglt.give(m, p)
 	require.NoError(t, err)
 	assert.Equal(t, m, ri.Meta)
-	assert.Equal(t, state.NsPreparingError, ri.State)
+	assert.Equal(t, state.NsNotFound, ri.State)
 
 	// Check that no range was created.
 	ri, ok := rglt.rangeInfo(m.Ident)
@@ -150,13 +150,6 @@ func TestGiveErrorSlow(t *testing.T) {
 		_, ok := rglt.rangeInfo(m.Ident)
 		return !ok
 	}, waitFor, tick)
-
-	for i := 0; i < 2; i++ {
-		ri, err := rglt.give(m, p)
-		require.NoError(t, err)
-		assert.Equal(t, m, ri.Meta)
-		assert.Equal(t, state.NsPreparingError, ri.State)
-	}
 }
 
 func setupServe(infos map[ranje.Ident]*info.RangeInfo, m ranje.Meta) {

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -145,7 +145,7 @@ func TestGiveErrorSlow(t *testing.T) {
 	// Unblock PrepareAddRange.
 	n.wgPrepareAddRange.Done()
 
-	// Wait until range vanishes (because PrepareAddRange returned error)
+	// Wait until range vanishes (because PrepareAddRange returned error).
 	require.Eventually(t, func() bool {
 		_, ok := rglt.rangeInfo(m.Ident)
 		return !ok
@@ -269,7 +269,7 @@ func TestServeErrorSlow(t *testing.T) {
 	// Unblock AddRange.
 	n.wgAddRange.Done()
 
-	// Wait until Prepared (because AddRange returned error).
+	// Wait until state returns to Prepared (because AddRange returned error).
 	require.Eventually(t, func() bool {
 		ri, ok := rglt.rangeInfo(m.Ident)
 		return ok && ri.State == state.NsPrepared
@@ -395,7 +395,7 @@ func TestTakeErrorSlow(t *testing.T) {
 	// Unblock PrepareDropRange.
 	n.wgPrepareDropRange.Done()
 
-	// Wait until Ready (because PrepareDropRange returned error).
+	// Wait until state returns to Ready (because PrepareDropRange returned error).
 	require.Eventually(t, func() bool {
 		ri, ok := rglt.rangeInfo(m.Ident)
 		return ok && ri.State == state.NsReady
@@ -452,7 +452,7 @@ func TestDropSlow(t *testing.T) {
 	// Unblock DropRange.
 	n.wgDropRange.Done()
 
-	// Wait until range is dropped.
+	// Wait until range vanishes.
 	require.Eventually(t, func() bool {
 		_, ok := rglt.rangeInfo(m.Ident)
 		return !ok
@@ -520,7 +520,7 @@ func TestDropErrorSlow(t *testing.T) {
 	// Unblock DropRange.
 	n.wgDropRange.Done()
 
-	// Wait until state is return to Taken (because DropRange returned error).
+	// Wait until state returns to Taken (because DropRange returned error).
 	require.Eventually(t, func() bool {
 		ri, ok := rglt.rangeInfo(m.Ident)
 		return ok && ri.State == state.NsTaken

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -245,12 +245,12 @@ func TestServeErrorFast(t *testing.T) {
 	ri, err := rglt.serve(m.Ident)
 	require.NoError(t, err)
 	assert.Equal(t, m, ri.Meta)
-	assert.Equal(t, state.NsReadyingError, ri.State)
+	assert.Equal(t, state.NsPrepared, ri.State)
 
 	// State was updated.
 	ri, ok := rglt.rangeInfo(m.Ident)
 	require.True(t, ok)
-	assert.Equal(t, state.NsReadyingError, ri.State)
+	assert.Equal(t, state.NsPrepared, ri.State)
 }
 
 func TestServeErrorSlow(t *testing.T) {
@@ -276,18 +276,11 @@ func TestServeErrorSlow(t *testing.T) {
 	// Unblock AddRange.
 	n.wgAddRange.Done()
 
-	// Wait until ReadyingError (because AddRange returned error).
+	// Wait until Prepared (because AddRange returned error).
 	require.Eventually(t, func() bool {
 		ri, ok := rglt.rangeInfo(m.Ident)
-		return ok && ri.State == state.NsReadyingError
+		return ok && ri.State == state.NsPrepared
 	}, waitFor, tick)
-
-	for i := 0; i < 2; i++ {
-		ri, err := rglt.serve(m.Ident)
-		require.Error(t, err)
-		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = invalid state for Serve: NsReadyingError")
-		assert.Equal(t, state.NsReadyingError, ri.State)
-	}
 }
 
 func setupTake(infos map[ranje.Ident]*info.RangeInfo, m ranje.Meta) {

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -378,12 +378,12 @@ func TestTakeErrorFast(t *testing.T) {
 	ri, err := rglt.take(m.Ident)
 	require.NoError(t, err)
 	assert.Equal(t, m, ri.Meta)
-	assert.Equal(t, state.NsTakingError, ri.State)
+	assert.Equal(t, state.NsReady, ri.State)
 
 	// Check state was updated.
 	ri, ok := rglt.rangeInfo(m.Ident)
 	require.True(t, ok)
-	assert.Equal(t, state.NsTakingError, ri.State)
+	assert.Equal(t, state.NsReady, ri.State)
 }
 
 func TestTakeErrorSlow(t *testing.T) {
@@ -409,18 +409,11 @@ func TestTakeErrorSlow(t *testing.T) {
 	// Unblock PrepareDropRange.
 	n.wgPrepareDropRange.Done()
 
-	// Wait until TakingError (because PrepareDropRange returned error).
+	// Wait until Ready (because PrepareDropRange returned error).
 	require.Eventually(t, func() bool {
 		ri, ok := rglt.rangeInfo(m.Ident)
-		return ok && ri.State == state.NsTakingError
+		return ok && ri.State == state.NsReady
 	}, waitFor, tick)
-
-	for i := 0; i < 2; i++ {
-		ri, err := rglt.serve(m.Ident)
-		require.Error(t, err)
-		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = invalid state for Serve: NsTakingError")
-		assert.Equal(t, state.NsTakingError, ri.State)
-	}
 }
 
 func setupDrop(infos map[ranje.Ident]*info.RangeInfo, m ranje.Meta) {

--- a/pkg/roster/state/remote_state.go
+++ b/pkg/roster/state/remote_state.go
@@ -16,7 +16,6 @@ const (
 
 	// Valid states.
 	NsPreparing
-	NsPreparingError
 	NsPrepared
 	NsReadying
 	NsReady
@@ -42,8 +41,6 @@ func RemoteStateFromProto(s pb.RangeNodeState) RemoteState {
 		return NsUnknown
 	case pb.RangeNodeState_PREPARING:
 		return NsPreparing
-	case pb.RangeNodeState_PREPARING_ERROR:
-		return NsPreparingError
 	case pb.RangeNodeState_PREPARED:
 		return NsPrepared
 	case pb.RangeNodeState_READYING:
@@ -70,8 +67,6 @@ func (rs RemoteState) ToProto() pb.RangeNodeState {
 		return pb.RangeNodeState_UNKNOWN
 	case NsPreparing:
 		return pb.RangeNodeState_PREPARING
-	case NsPreparingError:
-		return pb.RangeNodeState_PREPARING_ERROR
 	case NsPrepared:
 		return pb.RangeNodeState_PREPARED
 	case NsReadying:

--- a/pkg/roster/state/remote_state.go
+++ b/pkg/roster/state/remote_state.go
@@ -22,7 +22,6 @@ const (
 	NsReadyingError
 	NsReady
 	NsTaking
-	NsTakingError
 	NsTaken
 	NsDropping
 	NsDroppingError
@@ -57,8 +56,6 @@ func RemoteStateFromProto(s pb.RangeNodeState) RemoteState {
 		return NsReady
 	case pb.RangeNodeState_TAKING:
 		return NsTaking
-	case pb.RangeNodeState_TAKING_ERROR:
-		return NsTakingError
 	case pb.RangeNodeState_TAKEN:
 		return NsTaken
 	case pb.RangeNodeState_DROPPING:
@@ -91,8 +88,6 @@ func (rs RemoteState) ToProto() pb.RangeNodeState {
 		return pb.RangeNodeState_READY
 	case NsTaking:
 		return pb.RangeNodeState_TAKING
-	case NsTakingError:
-		return pb.RangeNodeState_TAKING_ERROR
 	case NsTaken:
 		return pb.RangeNodeState_TAKEN
 	case NsDropping:

--- a/pkg/roster/state/remote_state.go
+++ b/pkg/roster/state/remote_state.go
@@ -19,7 +19,6 @@ const (
 	NsPreparingError
 	NsPrepared
 	NsReadying
-	NsReadyingError
 	NsReady
 	NsTaking
 	NsTaken
@@ -50,8 +49,6 @@ func RemoteStateFromProto(s pb.RangeNodeState) RemoteState {
 		return NsPrepared
 	case pb.RangeNodeState_READYING:
 		return NsReadying
-	case pb.RangeNodeState_READYING_ERROR:
-		return NsReadyingError
 	case pb.RangeNodeState_READY:
 		return NsReady
 	case pb.RangeNodeState_TAKING:
@@ -82,8 +79,6 @@ func (rs RemoteState) ToProto() pb.RangeNodeState {
 		return pb.RangeNodeState_PREPARED
 	case NsReadying:
 		return pb.RangeNodeState_READYING
-	case NsReadyingError:
-		return pb.RangeNodeState_READYING_ERROR
 	case NsReady:
 		return pb.RangeNodeState_READY
 	case NsTaking:

--- a/pkg/roster/state/remote_state.go
+++ b/pkg/roster/state/remote_state.go
@@ -23,7 +23,6 @@ const (
 	NsTaking
 	NsTaken
 	NsDropping
-	NsDroppingError
 
 	// Special case: This is never returned by probes, since those only include
 	// the state of ranges which the node has. This is returned by redundant
@@ -57,8 +56,6 @@ func RemoteStateFromProto(s pb.RangeNodeState) RemoteState {
 		return NsTaken
 	case pb.RangeNodeState_DROPPING:
 		return NsDropping
-	case pb.RangeNodeState_DROPPING_ERROR:
-		return NsDroppingError
 	case pb.RangeNodeState_NOT_FOUND:
 		return NsNotFound
 	}
@@ -87,8 +84,6 @@ func (rs RemoteState) ToProto() pb.RangeNodeState {
 		return pb.RangeNodeState_TAKEN
 	case NsDropping:
 		return pb.RangeNodeState_DROPPING
-	case NsDroppingError:
-		return pb.RangeNodeState_DROPPING_ERROR
 	case NsNotFound:
 		return pb.RangeNodeState_NOT_FOUND
 	}

--- a/pkg/roster/state/remote_state_string.go
+++ b/pkg/roster/state/remote_state_string.go
@@ -13,18 +13,17 @@ func _() {
 	_ = x[NsPreparingError-2]
 	_ = x[NsPrepared-3]
 	_ = x[NsReadying-4]
-	_ = x[NsReadyingError-5]
-	_ = x[NsReady-6]
-	_ = x[NsTaking-7]
-	_ = x[NsTaken-8]
-	_ = x[NsDropping-9]
-	_ = x[NsDroppingError-10]
-	_ = x[NsNotFound-11]
+	_ = x[NsReady-5]
+	_ = x[NsTaking-6]
+	_ = x[NsTaken-7]
+	_ = x[NsDropping-8]
+	_ = x[NsDroppingError-9]
+	_ = x[NsNotFound-10]
 }
 
-const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyingErrorNsReadyNsTakingNsTakenNsDroppingNsDroppingErrorNsNotFound"
+const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyNsTakingNsTakenNsDroppingNsDroppingErrorNsNotFound"
 
-var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 71, 78, 86, 93, 103, 118, 128}
+var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 63, 71, 78, 88, 103, 113}
 
 func (i RemoteState) String() string {
 	if i >= RemoteState(len(_RemoteState_index)-1) {

--- a/pkg/roster/state/remote_state_string.go
+++ b/pkg/roster/state/remote_state_string.go
@@ -10,19 +10,18 @@ func _() {
 	var x [1]struct{}
 	_ = x[NsUnknown-0]
 	_ = x[NsPreparing-1]
-	_ = x[NsPreparingError-2]
-	_ = x[NsPrepared-3]
-	_ = x[NsReadying-4]
-	_ = x[NsReady-5]
-	_ = x[NsTaking-6]
-	_ = x[NsTaken-7]
-	_ = x[NsDropping-8]
-	_ = x[NsNotFound-9]
+	_ = x[NsPrepared-2]
+	_ = x[NsReadying-3]
+	_ = x[NsReady-4]
+	_ = x[NsTaking-5]
+	_ = x[NsTaken-6]
+	_ = x[NsDropping-7]
+	_ = x[NsNotFound-8]
 }
 
-const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyNsTakingNsTakenNsDroppingNsNotFound"
+const _RemoteState_name = "NsUnknownNsPreparingNsPreparedNsReadyingNsReadyNsTakingNsTakenNsDroppingNsNotFound"
 
-var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 63, 71, 78, 88, 98}
+var _RemoteState_index = [...]uint8{0, 9, 20, 30, 40, 47, 55, 62, 72, 82}
 
 func (i RemoteState) String() string {
 	if i >= RemoteState(len(_RemoteState_index)-1) {

--- a/pkg/roster/state/remote_state_string.go
+++ b/pkg/roster/state/remote_state_string.go
@@ -17,13 +17,12 @@ func _() {
 	_ = x[NsTaking-6]
 	_ = x[NsTaken-7]
 	_ = x[NsDropping-8]
-	_ = x[NsDroppingError-9]
-	_ = x[NsNotFound-10]
+	_ = x[NsNotFound-9]
 }
 
-const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyNsTakingNsTakenNsDroppingNsDroppingErrorNsNotFound"
+const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyNsTakingNsTakenNsDroppingNsNotFound"
 
-var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 63, 71, 78, 88, 103, 113}
+var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 63, 71, 78, 88, 98}
 
 func (i RemoteState) String() string {
 	if i >= RemoteState(len(_RemoteState_index)-1) {

--- a/pkg/roster/state/remote_state_string.go
+++ b/pkg/roster/state/remote_state_string.go
@@ -16,16 +16,15 @@ func _() {
 	_ = x[NsReadyingError-5]
 	_ = x[NsReady-6]
 	_ = x[NsTaking-7]
-	_ = x[NsTakingError-8]
-	_ = x[NsTaken-9]
-	_ = x[NsDropping-10]
-	_ = x[NsDroppingError-11]
-	_ = x[NsNotFound-12]
+	_ = x[NsTaken-8]
+	_ = x[NsDropping-9]
+	_ = x[NsDroppingError-10]
+	_ = x[NsNotFound-11]
 }
 
-const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyingErrorNsReadyNsTakingNsTakingErrorNsTakenNsDroppingNsDroppingErrorNsNotFound"
+const _RemoteState_name = "NsUnknownNsPreparingNsPreparingErrorNsPreparedNsReadyingNsReadyingErrorNsReadyNsTakingNsTakenNsDroppingNsDroppingErrorNsNotFound"
 
-var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 71, 78, 86, 99, 106, 116, 131, 141}
+var _RemoteState_index = [...]uint8{0, 9, 20, 36, 46, 56, 71, 78, 86, 93, 103, 118, 128}
 
 func (i RemoteState) String() string {
 	if i >= RemoteState(len(_RemoteState_index)-1) {


### PR DESCRIPTION
This removes all of the "error" states from clients, to bring them closer to the controller. I originally thought this was a good (and necessary) idea, so that the node could signal that it was in a weird state and needed help cleaning up, whether from an operator or just the controller. But I tried actually recovering from those states (e.g. TakingError) and found that it was exactly the same as just reverting back to the previous state (e.g. Ready) and trying again. If nodes want help cleaning up, then they can signal that out of band.

It should be part of the nodes contract to not enter states where they can't do anything. Rangelet-implementing methods should either advance to the success state (by returning nil), or revert to the previous state (by returning an error). If the error is such that they're stuck, then they should crash.

How did I accomplish this without changing the orchestrator tests? Easy, just have very shitty test coverage on the failure path. I actually had the idea to do this while trying to add that coverage and realizing that this was a hairball.