### PR TITLE
Unify Prepared and Taken states into Inactive

### DIFF
--- a/cmd/dumbbal/main.go
+++ b/cmd/dumbbal/main.go
@@ -82,7 +82,7 @@ func main() {
 
 		placements := []Placement{}
 		for i, p := range r.Placements {
-			if p.Placement.State == pb.PlacementState_PS_READY {
+			if p.Placement.State == pb.PlacementState_PS_ACTIVE {
 				placements = append(placements, Placement{
 					index: i,
 					info:  p.RangeInfo.Info,

--- a/examples/kv/pkg/node/fetcher.go
+++ b/examples/kv/pkg/node/fetcher.go
@@ -32,7 +32,7 @@ func newFetcher(rm ranje.Meta, parents []api.Parent) *fetcher {
 
 	for _, par := range parents {
 		for _, plc := range par.Placements {
-			if plc.State == ranje.PsReady {
+			if plc.State == ranje.PsActive {
 				src := src{meta: par.Meta, node: plc.Node}
 				srcs = append(srcs, src)
 			}

--- a/examples/kv/pkg/proxy/server.go
+++ b/examples/kv/pkg/proxy/server.go
@@ -23,7 +23,7 @@ func (ps *proxyServer) getClient(k string) (pbkv.KVClient, roster.Location, erro
 	loc := roster.Location{}
 
 	states := []state.RemoteState{
-		state.NsReady,
+		state.NsActive,
 	}
 
 	locations := ps.proxy.rost.LocateInState(ranje.Key(k), states)
@@ -35,7 +35,7 @@ func (ps *proxyServer) getClient(k string) (pbkv.KVClient, roster.Location, erro
 	// Prefer the ready node.
 	found := false
 	for i := range locations {
-		if locations[i].Info.State == state.NsReady {
+		if locations[i].Info.State == state.NsActive {
 			loc = locations[i]
 			found = true
 			break

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1,0 +1,161 @@
+package keyspace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/adammck/ranger/pkg/config"
+	"github.com/adammck/ranger/pkg/ranje"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlacementMayBecomeReady(t *testing.T) {
+	examples := []struct {
+		name   string
+		input  []*ranje.Range
+		output [][]bool
+	}{
+		{
+			name: "initial",
+			input: []*ranje.Range{
+				{
+					State:      ranje.RsActive,
+					Meta:       ranje.Meta{Ident: 1, Start: ranje.ZeroKey},
+					Placements: []*ranje.Placement{{NodeID: "n1", State: ranje.PsInactive}},
+				},
+			},
+			output: [][]bool{
+				{true}, // n1
+			},
+		},
+		{
+			name: "joining",
+			input: []*ranje.Range{
+				{
+					State:      ranje.RsSubsuming,
+					Children:   []ranje.Ident{3},
+					Meta:       ranje.Meta{Ident: 1, Start: ranje.ZeroKey, End: ranje.Key("ggg")},
+					Placements: []*ranje.Placement{{NodeID: "n1", State: ranje.PsInactive}},
+				},
+				{
+					State:      ranje.RsSubsuming,
+					Children:   []ranje.Ident{3},
+					Meta:       ranje.Meta{Ident: 2, Start: ranje.Key("ggg"), End: ranje.ZeroKey},
+					Placements: []*ranje.Placement{{NodeID: "n2", State: ranje.PsInactive}},
+				},
+				{
+					State:      ranje.RsActive,
+					Parents:    []ranje.Ident{1, 2},
+					Meta:       ranje.Meta{Ident: 3, Start: ranje.ZeroKey},
+					Placements: []*ranje.Placement{{NodeID: "n3", State: ranje.PsInactive}},
+				},
+			},
+			output: [][]bool{
+				{false}, // n1, should not advance, because subsumed
+				{false}, // n2, same
+				{true},  // n3
+			},
+		},
+	}
+
+	for _, ex := range examples {
+		pers := &FakePersister{ranges: ex.input}
+		ks, err := New(configForTest(), pers)
+		require.NoError(t, err)
+
+		for r := 0; r < len(ex.input); r++ {
+			for p := 0; p < len(ex.input[r].Placements); p++ {
+				assert.Equal(t, ex.output[r][p], ks.PlacementMayBecomeReady(ex.input[r].Placements[p]), "r=%d, p=%d", r, p)
+			}
+		}
+	}
+}
+
+func TestPlacementMayBeTaken(t *testing.T) {
+	examples := []struct {
+		name   string
+		input  []*ranje.Range
+		output [][]bool
+	}{
+		{
+			name: "ready with no replacement",
+			input: []*ranje.Range{
+				{
+					State:      ranje.RsActive,
+					Meta:       ranje.Meta{Ident: 1, Start: ranje.ZeroKey},
+					Placements: []*ranje.Placement{{NodeID: "n1", State: ranje.PsActive}},
+				},
+			},
+			output: [][]bool{
+				{false}, // n1
+			},
+		},
+		{
+			name: "joining",
+			input: []*ranje.Range{
+				{
+					State:      ranje.RsSubsuming,
+					Children:   []ranje.Ident{3},
+					Meta:       ranje.Meta{Ident: 1, Start: ranje.ZeroKey, End: ranje.Key("ggg")},
+					Placements: []*ranje.Placement{{NodeID: "n1", State: ranje.PsActive}},
+				},
+				{
+					State:      ranje.RsSubsuming,
+					Children:   []ranje.Ident{3},
+					Meta:       ranje.Meta{Ident: 2, Start: ranje.Key("ggg"), End: ranje.ZeroKey},
+					Placements: []*ranje.Placement{{NodeID: "n2", State: ranje.PsActive}},
+				},
+				{
+					State:      ranje.RsActive,
+					Parents:    []ranje.Ident{1, 2},
+					Meta:       ranje.Meta{Ident: 3, Start: ranje.ZeroKey},
+					Placements: []*ranje.Placement{{NodeID: "n3", State: ranje.PsInactive}},
+				},
+			},
+			output: [][]bool{
+				{true},  // n1
+				{true},  // n2
+				{false}, // n3
+			},
+		},
+	}
+
+	for _, ex := range examples {
+		pers := &FakePersister{ranges: ex.input}
+		ks, err := New(configForTest(), pers)
+		require.NoError(t, err)
+
+		for r := 0; r < len(ex.input); r++ {
+			for p := 0; p < len(ex.input[r].Placements); p++ {
+				assert.Equal(t, ex.output[r][p], ks.PlacementMayBeTaken(ex.input[r].Placements[p]))
+			}
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+// TODO: Remove this when global config goes away.
+func configForTest() config.Config {
+	return config.Config{
+		DrainNodesBeforeShutdown: false,
+		NodeExpireDuration:       1 * time.Hour, // never
+		Replication:              1,
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+// TODO: Unify this with the one in orchestrator_test.go
+type FakePersister struct {
+	ranges []*ranje.Range
+}
+
+func (fp *FakePersister) GetRanges() ([]*ranje.Range, error) {
+	return fp.ranges, nil
+}
+
+func (fp *FakePersister) PutRanges([]*ranje.Range) error {
+	return nil
+}

--- a/pkg/proto/node.proto
+++ b/pkg/proto/node.proto
@@ -10,7 +10,6 @@ service Node {
   rpc Give (GiveRequest) returns (GiveResponse) {}
   rpc Serve (ServeRequest) returns (ServeResponse) {}
   rpc Take (TakeRequest) returns (TakeResponse) {}
-  rpc Untake (UntakeRequest) returns (UntakeResponse) {}
   rpc Drop (DropRequest) returns (DropResponse) {}
 
   // Controller wants to know the state of the node, including its ranges.
@@ -63,13 +62,6 @@ message TakeRequest {
 
 message TakeResponse {
   RangeNodeState state = 1;
-}
-
-message UntakeRequest {
-  uint64 range = 1;
-}
-
-message UntakeResponse {
 }
 
 message DropRequest {

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -54,22 +54,26 @@ message RangeInfo {
  }
 
 // TODO: Rename to RemoteState, like the non-proto type.
-// Keep synced with RangeState (in node.go for now)
+// Keep synced with roster/state.RemoteState (in pkg/roster/state/remote_state.go)
 enum RangeNodeState {
   UNKNOWN = 0;
-  PREPARING = 1;
-  PREPARED = 2;
-  READYING = 3;
-  READY = 4;
-  TAKING = 5;
-  TAKEN = 6;
-  DROPPING = 7;
+
+  // Stable states
+  INACTIVE = 1;
+  ACTIVE = 2;
+
+  // During transitions
+  LOADING = 3;      // Pending -> PreReady
+  ACTIVATING = 4;   // PreReady -> Ready
+  DEACTIVATING = 5; // Ready -> PreReady
+  DROPPING = 6;     // PreReady -> NotFound
+
   // Special case: See roster.RemoteState
-  NOT_FOUND = 8;
+  NOT_FOUND = 7;
 }
 
 // This is only for debugging purposes, for now.
-// Keep synced with ranje.RangeState (in pkg/ranje/state_range.go)
+// Keep synced with ranje.RangeState (in pkg/ranje/range_state.go)
 enum RangeState {
   RS_UNKNOWN = 0;
   RS_ACTIVE = 1;
@@ -78,13 +82,12 @@ enum RangeState {
 }
 
 // This is only for debugging purposes, for now.
-// Keep synced with ranje.PlacementState (in pkg/ranje/state_placement.go)
+// Keep synced with ranje.PlacementState (in pkg/ranje/placement_state.go)
 enum PlacementState {
   PS_UNKNOWN = 0;
   PS_PENDING = 1;
-  PS_PREPARED = 2;
-  PS_READY = 3;
-  PS_TAKEN = 4;
+  PS_INACTIVE = 2;
+  PS_ACTIVE = 3;
   PS_GIVE_UP = 5;
   PS_DROPPED = 6;
 }

--- a/pkg/rangelet/server.go
+++ b/pkg/rangelet/server.go
@@ -158,8 +158,3 @@ func (ns *NodeServer) Info(ctx context.Context, req *pb.InfoRequest) (*pb.InfoRe
 func (ns *NodeServer) Ranges(ctx context.Context, req *pb.RangesRequest) (*pb.RangesResponse, error) {
 	panic("not imlemented!")
 }
-
-// TODO: Remove this method? Taken->Ready is no longer valid.
-func (ns *NodeServer) Untake(ctx context.Context, req *pb.UntakeRequest) (*pb.UntakeResponse, error) {
-	panic("not imlemented!")
-}

--- a/pkg/ranje/placement.go
+++ b/pkg/ranje/placement.go
@@ -95,8 +95,8 @@ func (p *Placement) ToState(new PlacementState) error {
 		return fmt.Errorf("invalid placement state transition: %s -> %s", old.String(), new.String())
 	}
 
-	// Special case: When entering PsReady, fire the optional callback.
-	if new == PsReady {
+	// Special case: When entering PsActive, fire the optional callback.
+	if new == PsActive {
 		if p.onReady != nil {
 			p.onReady()
 		}

--- a/pkg/ranje/placement_state_string.go
+++ b/pkg/ranje/placement_state_string.go
@@ -10,16 +10,15 @@ func _() {
 	var x [1]struct{}
 	_ = x[PsUnknown-0]
 	_ = x[PsPending-1]
-	_ = x[PsPrepared-2]
-	_ = x[PsReady-3]
-	_ = x[PsTaken-4]
-	_ = x[PsGiveUp-5]
-	_ = x[PsDropped-6]
+	_ = x[PsInactive-2]
+	_ = x[PsActive-3]
+	_ = x[PsGiveUp-4]
+	_ = x[PsDropped-5]
 }
 
-const _PlacementState_name = "PsUnknownPsPendingPsPreparedPsReadyPsTakenPsGiveUpPsDropped"
+const _PlacementState_name = "PsUnknownPsPendingPsInactivePsActivePsGiveUpPsDropped"
 
-var _PlacementState_index = [...]uint8{0, 9, 18, 28, 35, 42, 50, 59}
+var _PlacementState_index = [...]uint8{0, 9, 18, 28, 36, 44, 53}
 
 func (i PlacementState) String() string {
 	if i >= PlacementState(len(_PlacementState_index)-1) {

--- a/pkg/roster/node_rpc.go
+++ b/pkg/roster/node_rpc.go
@@ -94,7 +94,7 @@ func (n *Node) Serve(ctx context.Context, p *ranje.Placement) error {
 }
 
 func (n *Node) Take(ctx context.Context, p *ranje.Placement) error {
-	log.Printf("taking %s from %s...", p.LogString(), n.Ident())
+	log.Printf("deactivating %s from %s...", p.LogString(), n.Ident())
 	rID := p.Range().Meta.Ident
 
 	// TODO: Include range parents
@@ -109,7 +109,7 @@ func (n *Node) Take(ctx context.Context, p *ranje.Placement) error {
 	// TODO: Retry a few times before giving up.
 	res, err := n.client.Take(ctx, req)
 	if err != nil {
-		log.Printf("error taking %s from %s: %v", p.LogString(), n.Ident(), err)
+		log.Printf("error deactivating %s from %s: %v", p.LogString(), n.Ident(), err)
 		return err
 	}
 

--- a/pkg/roster/roster_test.go
+++ b/pkg/roster/roster_test.go
@@ -92,14 +92,14 @@ func (ts *RosterSuite) TestCandidateByNodeID() {
 		State: ranje.RsActive,
 		Placements: []*ranje.Placement{{
 			NodeID: aRem.Ident,
-			State:  ranje.PsReady,
+			State:  ranje.PsActive,
 		}},
 	}
 
 	aInfos := map[ranje.Ident]*info.RangeInfo{
 		r.Meta.Ident: {
 			Meta:  r.Meta,
-			State: state.NsReady,
+			State: state.NsActive,
 		},
 	}
 
@@ -157,14 +157,14 @@ func (ts *RosterSuite) TestProbeOne() {
 		State: ranje.RsActive,
 		Placements: []*ranje.Placement{{
 			NodeID: rem.Ident,
-			State:  ranje.PsReady,
+			State:  ranje.PsActive,
 		}},
 	}
 
 	fakeInfos := map[ranje.Ident]*info.RangeInfo{
 		r.Meta.Ident: {
 			Meta:  r.Meta,
-			State: state.NsReady,
+			State: state.NsActive,
 			Info: info.LoadInfo{
 				Keys: 123,
 			},

--- a/pkg/roster/state/remote_state_string.go
+++ b/pkg/roster/state/remote_state_string.go
@@ -9,19 +9,18 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[NsUnknown-0]
-	_ = x[NsPreparing-1]
-	_ = x[NsPrepared-2]
-	_ = x[NsReadying-3]
-	_ = x[NsReady-4]
-	_ = x[NsTaking-5]
-	_ = x[NsTaken-6]
-	_ = x[NsDropping-7]
-	_ = x[NsNotFound-8]
+	_ = x[NsInactive-1]
+	_ = x[NsActive-2]
+	_ = x[NsLoading-3]
+	_ = x[NsActivating-4]
+	_ = x[NsDeactivating-5]
+	_ = x[NsDropping-6]
+	_ = x[NsNotFound-7]
 }
 
-const _RemoteState_name = "NsUnknownNsPreparingNsPreparedNsReadyingNsReadyNsTakingNsTakenNsDroppingNsNotFound"
+const _RemoteState_name = "NsUnknownNsInactiveNsActiveNsLoadingNsActivatingNsDeactivatingNsDroppingNsNotFound"
 
-var _RemoteState_index = [...]uint8{0, 9, 20, 30, 40, 47, 55, 62, 72, 82}
+var _RemoteState_index = [...]uint8{0, 9, 19, 27, 36, 48, 62, 72, 82}
 
 func (i RemoteState) String() string {
 	if i >= RemoteState(len(_RemoteState_index)-1) {

--- a/pkg/test/fake_node/barrier.go
+++ b/pkg/test/fake_node/barrier.go
@@ -1,24 +1,30 @@
 package fake_node
 
 import (
+	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 type barrier struct {
+	desc    string // just for error messages
+	arrived uint32
 	arrival *sync.WaitGroup
 	release *sync.WaitGroup
 	cb      func()
 }
 
-func NewBarrier(n int, cb func()) *barrier {
+func NewBarrier(desc string, n int, cb func()) *barrier {
 	a := &sync.WaitGroup{}
 	b := &sync.WaitGroup{}
 	a.Add(n)
 	b.Add(n)
 
-	return &barrier{a, b, cb}
+	return &barrier{desc, 0, a, b, cb}
 }
 
+// Wait blocks until Arrive has been called.
+// TODO: Rename this to e.g. AwaitBarrier.
 func (b *barrier) Wait() {
 	b.arrival.Wait()
 }
@@ -27,12 +33,22 @@ func (b *barrier) Wait() {
 // blocked in Arrive. Before returning, as a convenience, it calls the callback
 // (which is probably a WaitGroup on the rangelet changing state) so the caller
 // doesn't have to wait for that itself.
+// TODO: Rename this to e.g. CompleteTransition.
 func (b *barrier) Release() {
+	if atomic.LoadUint32(&b.arrived) == 0 {
+		panic(fmt.Sprintf("Release called before Arrive for barrier: %s", b.desc))
+	}
+
 	b.release.Done()
 	b.cb()
 }
 
 func (b *barrier) Arrive() {
+	if atomic.LoadUint32(&b.arrived) == 1 {
+		panic(fmt.Sprintf("Arrive already called for barrier: %s", b.desc))
+	}
+
+	atomic.StoreUint32(&b.arrived, 1)
 	b.arrival.Done()
 	b.release.Wait()
 }


### PR DESCRIPTION
Wow this was harder work than expected. The orchestrator tests are currently quite brittle, often deadlocking rather than failing when something doesn't happen as expected. Not ideal for refactoring. But it does work now. See the linked bug for details on why this is a good idea.

Test plan: Trust me bro
Closes #16.