### PR TITLE
Add rangerctl flag to render to graphviz

### DIFF
--- a/pkg/orchestrator/server_debug.go
+++ b/pkg/orchestrator/server_debug.go
@@ -18,9 +18,21 @@ type debugServer struct {
 }
 
 func rangeResponse(r *ranje.Range, rost *roster.Roster) *pb.RangeResponse {
+	parents := make([]uint64, len(r.Parents))
+	for i, r := range r.Parents {
+		parents[i] = r.ToProto()
+	}
+
+	children := make([]uint64, len(r.Children))
+	for i, r := range r.Children {
+		children[i] = r.ToProto()
+	}
+
 	res := &pb.RangeResponse{
-		Meta:  r.Meta.ToProto(),
-		State: r.State.ToProto(),
+		Meta:     r.Meta.ToProto(),
+		State:    r.State.ToProto(),
+		Parents:  parents,
+		Children: children,
 	}
 
 	for _, p := range r.Placements {

--- a/pkg/proto/debug.proto
+++ b/pkg/proto/debug.proto
@@ -27,7 +27,13 @@ message PlacementWithRangeInfo {
 message RangeResponse {
   RangeMeta meta = 1;
   RangeState state = 2;
-  repeated PlacementWithRangeInfo placements = 3;
+
+  // These two are obviously redundant when all ranges are dumped, but the
+  // output is intended to be useful, not correct.
+  repeated uint64 parents = 3;
+  repeated uint64 children = 4;
+
+  repeated PlacementWithRangeInfo placements = 5;
 }
 
 message NodesListRequest {


### PR DESCRIPTION
Perhaps my most pointless extravagance yet:

```
./rangerctl -render ranges | dot -Tsvg -o/tmp/ranges.svg && open /tmp/ranges.svg
```

![example](https://user-images.githubusercontent.com/19543/197447921-6a781b7d-2bde-495c-bab6-7f89ad21c49b.svg)

This is especially useful when running the example dev server and viewing the svg in an application like [Gapplin](http://gapplin.wolfrosch.com) which will auto-reload files as they change in the background (which Preview inexplicably does not). I'm running it in a loop for now, but maybe I'll add a watch/streaming interface some time, to notify on any state changes. That would be useful for any kind of remote viewer.