### PR TITLE
Streaming assignment watcher

### DIFF
--- a/examples/kv/pkg/node/node.go
+++ b/examples/kv/pkg/node/node.go
@@ -75,7 +75,7 @@ func New(addrLis, addrPub string, drainBeforeShutdown bool, logReqs bool, chaos 
 		chaos:   chaos,
 	}
 
-	rglt := rangelet.NewRangelet(n, srv, &null.NullStorage{})
+	rglt := rangelet.New(n, srv, &null.NullStorage{})
 	n.rglt = rglt
 
 	kv := kvServer{node: n}

--- a/pkg/actuator/rpc/actuator_test.go
+++ b/pkg/actuator/rpc/actuator_test.go
@@ -319,9 +319,8 @@ func (ns *NodeServer) Info(ctx context.Context, req *pb.InfoRequest) (*pb.InfoRe
 	return nil, fmt.Errorf("not implemented")
 }
 
-// TODO: Has this been subsumed by Info? Nobody seems to call it.
-func (ns *NodeServer) Ranges(ctx context.Context, req *pb.RangesRequest) (*pb.RangesResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+func (ns *NodeServer) Ranges(req *pb.RangesRequest, stream pb.Node_RangesServer) error {
+	return fmt.Errorf("not implemented")
 }
 
 // From: https://harrigan.xyz/blog/testing-go-grpc-server-using-an-in-memory-buffer-with-bufconn/

--- a/pkg/discovery/consul/discoverer.go
+++ b/pkg/discovery/consul/discoverer.go
@@ -1,0 +1,174 @@
+package consul
+
+import (
+	"sync"
+	"time"
+
+	"github.com/adammck/ranger/pkg/api"
+	"github.com/adammck/ranger/pkg/discovery"
+	consulapi "github.com/hashicorp/consul/api"
+	"google.golang.org/grpc"
+)
+
+type Discoverer struct {
+	consul *consulapi.Client
+	srv    *grpc.Server
+}
+
+// TODO: Take a consul API client here, not a cfg.
+func NewDiscoverer(cfg *consulapi.Config, srv *grpc.Server) (*Discoverer, error) {
+	client, err := consulapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &Discoverer{
+		consul: client,
+		srv:    srv,
+	}
+
+	return d, nil
+}
+
+type discoveryGetter struct {
+	disc *Discoverer
+	name string
+
+	// stop is closed to signal that run should stop ticking and return.
+	stop chan bool
+
+	// running can be waited on to block until run is about to return. Wait on
+	// this after closing stop to ensure that no more ticks will happen.
+	running sync.WaitGroup
+
+	// Remotes that we know about.
+	remotes   map[string]api.Remote
+	remotesMu sync.RWMutex
+
+	// Functions to be called when new remotes are added and removed.
+	add    func(api.Remote)
+	remove func(api.Remote)
+}
+
+func (d *Discoverer) Discover(svcName string, add, remove func(api.Remote)) discovery.Getter {
+	dg := &discoveryGetter{
+		disc:    d,
+		name:    svcName,
+		stop:    make(chan bool),
+		remotes: map[string]api.Remote{},
+		add:     add,
+		remove:  remove,
+	}
+
+	dg.running.Add(1)
+	go dg.run()
+
+	return dg
+}
+
+func (dg *discoveryGetter) tick() error {
+
+	// Fetch all entries (remotes) for the service name.
+	res, _, err := dg.disc.consul.Catalog().Service(dg.name, "", &consulapi.QueryOptions{})
+	if err != nil {
+		return err
+	}
+
+	seen := map[string]struct{}{}
+	added := []api.Remote{}
+	removed := []api.Remote{}
+
+	dg.remotesMu.Lock()
+
+	// Check every remote, see if it needs adding to our cache.
+	for _, r := range res {
+		svcID := r.ServiceID
+		seen[svcID] = struct{}{}
+
+		// Already known
+		if _, ok := dg.remotes[svcID]; ok {
+			continue
+		}
+
+		rem := api.Remote{
+			Ident: svcID,
+			Host:  r.Address, // https://github.com/hashicorp/consul/issues/2076
+			Port:  r.ServicePort,
+		}
+
+		// New remote
+		dg.remotes[svcID] = rem
+		added = append(added, rem)
+		//log.Printf("Added: %s", svcID)
+	}
+
+	// Remove any nodes which have gone from consul.
+	for svcID, rem := range dg.remotes {
+		if _, ok := seen[svcID]; !ok {
+			delete(dg.remotes, svcID)
+			removed = append(removed, rem)
+			//log.Printf("Removing: %s", svcID)
+		}
+	}
+
+	dg.remotesMu.Unlock()
+
+	// Call add/remove callbacks outside of lock. But still synchronously inside
+	// this function, so that we won't tick again until they return. Should keep
+	// things linear (i.e. no remotes being removed before they're added).
+
+	if dg.add != nil {
+		for _, rem := range added {
+			dg.add(rem)
+		}
+	}
+
+	if dg.remove != nil {
+		for _, rem := range removed {
+			dg.remove(rem)
+		}
+	}
+
+	return nil
+}
+
+func (dg *discoveryGetter) run() {
+	ticker := time.NewTicker(1 * time.Second)
+
+	for {
+		select {
+		case <-ticker.C:
+			dg.tick()
+		case <-dg.stop:
+			ticker.Stop()
+			dg.running.Done()
+			return
+		}
+	}
+}
+
+func (dg *discoveryGetter) Get() ([]api.Remote, error) {
+	dg.remotesMu.RLock()
+	defer dg.remotesMu.RUnlock()
+
+	res := make([]api.Remote, len(dg.remotes))
+	i := 0
+	for _, v := range dg.remotes {
+		res[i] = v
+		i += 1
+	}
+
+	return res, nil
+}
+
+// TODO: Could probably accomplish this with a cancellable context instead?
+func (dg *discoveryGetter) Stop() error {
+
+	// Signal run to return instead of tick again.
+	close(dg.stop)
+
+	// Block until any in-progress ticks are finished.
+	dg.running.Wait()
+
+	return nil
+}

--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -8,8 +8,29 @@ import "github.com/adammck/ranger/pkg/api"
 // This is not a general-purpose service discovery interface! This is just the
 // specific thing that I need for this library, to avoid letting Consul details
 // get all over the place.
+//
+// TODO: Extract the parts of these implementations which belong in Discoverer!
+//       Some services don't need to do both things. And even if they do, it's
+//       possible that they want to use different implementations.
+//
 type Discoverable interface {
 	Start() error
 	Stop() error
 	Get(string) ([]api.Remote, error)
+}
+
+// Discoverer is an interface to find other services by name.
+type Discoverer interface {
+	Discover(svcName string, add, remove func(api.Remote)) Getter
+}
+
+type Getter interface {
+
+	// Get returns all of the currently known remotes.
+	// TODO: Support some kind of filters here, like region and AZ.
+	Get() ([]api.Remote, error)
+
+	// Stop terminates this getter. It should not call the remove callback for
+	// any known remotes. Get will return no results after this is called.
+	Stop() error
 }

--- a/pkg/discovery/mock/mock.go
+++ b/pkg/discovery/mock/mock.go
@@ -1,4 +1,4 @@
-package consul
+package mock
 
 import (
 	"sync"

--- a/pkg/discovery/mock/mock_discoverer.go
+++ b/pkg/discovery/mock/mock_discoverer.go
@@ -1,0 +1,75 @@
+package mock
+
+import (
+	"sync"
+
+	"github.com/adammck/ranger/pkg/api"
+	discovery "github.com/adammck/ranger/pkg/discovery"
+)
+
+type Discoverer struct {
+	getters []*discoveryGetter
+
+	// svcName (e.g. "node") -> remotes
+	remotes   map[string][]api.Remote
+	remotesMu sync.RWMutex
+}
+
+func NewDiscoverer() *Discoverer {
+	return &Discoverer{
+		remotes: map[string][]api.Remote{},
+	}
+}
+
+type discoveryGetter struct {
+	disc    *Discoverer
+	svcName string
+
+	// Functions to be called when new remotes are added and removed.
+	add    func(api.Remote)
+	remove func(api.Remote)
+}
+
+func (d *Discoverer) Discover(svcName string, add, remove func(api.Remote)) discovery.Getter {
+	dg := &discoveryGetter{
+		disc:    d,
+		svcName: svcName,
+		add:     add,
+		remove:  remove,
+	}
+	d.getters = append(d.getters, dg)
+	return dg
+}
+
+func (dg *discoveryGetter) Get() ([]api.Remote, error) {
+	dg.disc.remotesMu.RLock()
+	defer dg.disc.remotesMu.RUnlock()
+
+	remotes, ok := dg.disc.remotes[dg.svcName]
+	if !ok {
+		return []api.Remote{}, nil
+	}
+
+	res := make([]api.Remote, len(remotes))
+	copy(res, remotes)
+
+	return res, nil
+}
+
+func (dg *discoveryGetter) Stop() error {
+	return nil
+}
+
+// test helpers
+
+func (d *Discoverer) Add(svcName string, remote api.Remote) {
+	d.remotesMu.RLock()
+	defer d.remotesMu.RUnlock()
+
+	// TODO: Need to init slice?
+	d.remotes[svcName] = append(d.remotes[svcName], remote)
+
+	for _, dg := range d.getters {
+		dg.add(remote)
+	}
+}

--- a/pkg/proto/node.proto
+++ b/pkg/proto/node.proto
@@ -18,7 +18,7 @@ service Node {
 
   // Proxy wants to know what it can forward to this node.
   // Controller shouldn't call this; use Info instead.
-  rpc Ranges (RangesRequest) returns (RangesResponse) {}
+  rpc Ranges (RangesRequest) returns (stream RangesResponse) {}
 }
 
 message Parent {
@@ -85,18 +85,9 @@ message InfoResponse {
 }
 
 message RangesRequest {
-  // The requests that the proxy is interested in forwarding. Nodes may filter
-  // out ranges which aren't currently in a state that can serve requests not
-  // in this list. E.g. for the kv example, can't accept writes after Take.
-  repeated string symbols = 1;
-}
-
-// This is like a short version of RangeInfo.
-message RangeMetaState {
-  RangeMeta meta = 1;
-  RangeNodeState state = 2;
 }
 
 message RangesResponse {
-  repeated RangeMetaState ranges = 1;
+  RangeMeta meta = 1;
+  RangeNodeState state = 2;
 }

--- a/pkg/rangelet/mirror/mirror.go
+++ b/pkg/rangelet/mirror/mirror.go
@@ -1,0 +1,274 @@
+// Package mirror provides a range assignment mirror, which can maintain a map
+// of all range assignments via the streaming Node.Ranges endpoint provided by
+// the rangelet. This is useful for proxies and clients wishing to forward
+// requests to the relevant node(s).
+//
+// Note that this interface is eventually consistent, in that the orchestrator
+// doesn't wait for clients to ack changes to the keyspace or anything like it.
+// This interface doesn't even care what the orchestrator or even keyspace say;
+// it simply reports what placements nodes report when probed or in response to
+// actuations. The clients' mirror will thus always be a bit out of date.
+package mirror
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/adammck/ranger/pkg/api"
+	"github.com/adammck/ranger/pkg/discovery"
+	"github.com/adammck/ranger/pkg/proto/conv"
+	pb "github.com/adammck/ranger/pkg/proto/gen"
+	"google.golang.org/grpc"
+)
+
+// Result is returned by the Find method. Don't use it for anything else.
+type Result struct {
+	NodeID  api.NodeID
+	RangeID api.RangeID
+	State   api.RemoteState
+}
+
+type Dialler func(context.Context, api.Remote) (*grpc.ClientConn, error)
+
+type Mirror struct {
+	ctx  context.Context
+	disc discovery.Getter
+
+	nodes   map[api.NodeID]*node
+	nodesMu sync.RWMutex
+
+	// Dialler takes a remote and returns a gRPC client connection. This is only
+	// parameterized for testing.
+	dialler Dialler
+}
+
+type node struct {
+	closer   chan bool
+	conn     *grpc.ClientConn
+	ranges   []api.RangeInfo
+	rangesMu sync.RWMutex
+}
+
+func (n *node) stop() {
+	//close(n.closer)
+	n.conn.Close()
+}
+
+func New(disc discovery.Discoverer) *Mirror {
+	m := &Mirror{
+		ctx:   context.Background(),
+		nodes: map[api.NodeID]*node{},
+	}
+	m.disc = disc.Discover("node", m.add, m.remove)
+	return m
+}
+
+func (m *Mirror) WithDialler(d Dialler) *Mirror {
+	m.dialler = d
+	return m
+}
+
+func (m *Mirror) add(rem api.Remote) {
+	log.Printf("Adding: %s", rem.NodeID())
+
+	conn, err := m.dialler(m.ctx, rem)
+	if err != nil {
+		log.Printf("Error dialling new remote: %v", err)
+		return
+	}
+
+	n := &node{
+		closer: make(chan bool, 1),
+		conn:   conn,
+	}
+
+	m.nodesMu.Lock()
+	m.nodes[rem.NodeID()] = n
+	m.nodesMu.Unlock()
+
+	go run(conn, n)
+}
+
+func (m *Mirror) remove(rem api.Remote) {
+	nID := rem.NodeID()
+	log.Printf("Removing: %s", nID)
+
+	m.nodesMu.Lock()
+
+	n, ok := m.nodes[nID]
+	if !ok {
+		m.nodesMu.Unlock()
+		return
+	}
+
+	delete(m.nodes, nID)
+
+	// Release and let closers happen outside the lock.
+	m.nodesMu.Unlock()
+
+	n.stop()
+}
+
+func (m *Mirror) Stop() error {
+
+	err := m.disc.Stop()
+	if err != nil {
+		// Not ideal, but we still want to stop the nodes.
+		log.Printf("Error stopping discovery getter: %s", err)
+	}
+
+	m.nodesMu.Lock()
+	defer m.nodesMu.Unlock()
+
+	// Call all closers concurrently.
+	wg := sync.WaitGroup{}
+	for k := range m.nodes {
+		wg.Add(1)
+		n := m.nodes[k]
+		go func() {
+			n.stop()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	m.nodes = map[api.NodeID]*node{}
+
+	return nil
+}
+
+var ErrNoSuchClientConn = errors.New("no such connection")
+
+// Conn returns a connection to the given node ID. This is just a convenience
+// for callers; the mirror needs to have a connection to every node in order to
+// receive their range assignments, so callers may wish to reuse it to exchange
+// other RPCs rather than creating a new one.
+//
+// Note that because the connection is owned by the Mirror, may be closed while
+// the user is trying to use it. If that isn't acceptable, callers should manage
+// their own connections.
+func (m *Mirror) Conn(nID api.NodeID) (*grpc.ClientConn, bool) {
+	m.nodesMu.RLock()
+	n, ok := m.nodes[nID]
+	m.nodesMu.RUnlock()
+	return n.conn, ok
+}
+
+func (m *Mirror) Find(key api.Key, states ...api.RemoteState) []Result {
+	results := []Result{}
+
+	m.nodesMu.RLock()
+	defer m.nodesMu.RUnlock()
+
+	// look i'm in a hurry here okay
+	for nID, n := range m.nodes {
+		n.rangesMu.RLock()
+		defer n.rangesMu.RUnlock()
+
+		for _, ri := range n.ranges {
+			if ri.Meta.Contains(key) {
+
+				// Skip if not in one of given states.
+				if len(states) > 0 {
+					ok := false
+					for _, s := range states {
+						if ri.State == s {
+							ok = true
+							break
+						}
+					}
+					if !ok {
+						continue
+					}
+				}
+
+				results = append(results, Result{
+					NodeID:  nID,
+					RangeID: ri.Meta.Ident,
+					State:   ri.State,
+				})
+			}
+		}
+	}
+
+	return results
+}
+
+func run(conn *grpc.ClientConn, node *node) {
+	client := pb.NewNodeClient(conn)
+
+	req := &pb.RangesRequest{}
+	stream, err := client.Ranges(context.Background(), req)
+	if err != nil {
+		log.Printf("Error fetching ranges: %s", err)
+		return
+	}
+
+	for {
+		res, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Printf("Error fetching ranges: %s", err)
+			break
+		}
+
+		update(node, res)
+	}
+}
+
+func update(n *node, res *pb.RangesResponse) {
+	log.Printf("res: %v", res)
+
+	meta, err := conv.MetaFromProto(res.Meta)
+	if err != nil {
+		// This should never happen.
+		log.Printf("Error parsing Range Meta from proto: %s", err)
+		return
+	}
+
+	state := conv.RemoteStateFromProto(res.State)
+	if state == api.NsUnknown {
+		// This should also never happen.
+		log.Printf("Error updating range state: got NsUnknown for rid=%s", meta.Ident)
+		return
+	}
+
+	// TODO: This is pretty coarse, maybe optimize.
+	n.rangesMu.Lock()
+	defer n.rangesMu.Unlock()
+
+	// Find the range by Range ID, and update the state. Meta is immutable after
+	// range construction, so assume it hasn't changed. God help us if it has.
+	for i := range n.ranges {
+		if n.ranges[i].Meta.Ident == meta.Ident {
+			if state == api.NsNotFound {
+				// Special case: Remove the range if it's NotFound.
+				x := len(n.ranges) - 1
+				n.ranges[i] = n.ranges[x]
+				n.ranges = n.ranges[:x]
+			} else {
+				// Normal case: Update the state.
+				n.ranges[i].State = state
+			}
+			return
+		}
+	}
+
+	// Haven't returned? First time we're seeing this range, so insert it unless
+	// it was NotFound (which could happen if the proxy is starting up just as a
+	// node is dropping a range, but probably never otherwise).
+
+	if state == api.NsNotFound {
+		return
+	}
+
+	n.ranges = append(n.ranges, api.RangeInfo{
+		Meta:  meta,
+		State: state,
+	})
+}

--- a/pkg/rangelet/mirror/mirror_test.go
+++ b/pkg/rangelet/mirror/mirror_test.go
@@ -1,0 +1,171 @@
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/adammck/ranger/pkg/api"
+	mock_disc "github.com/adammck/ranger/pkg/discovery/mock"
+	"github.com/adammck/ranger/pkg/proto/conv"
+	pb "github.com/adammck/ranger/pkg/proto/gen"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+)
+
+func TestEmpty(t *testing.T) {
+	h := setup(t)
+	res := h.mirror.Find(api.Key("aaa"))
+	assert.Assert(t, cmp.Len(res, 0))
+}
+
+func TestStatic(t *testing.T) {
+	h := setup(t)
+	h.add(t, api.Remote{
+		Ident: "aaa",
+		Host:  "host-aaa",
+	}, []api.RangeInfo{
+		{
+			Meta:  api.Meta{Ident: 1, End: api.Key("ggg")},
+			State: api.NsActive,
+		},
+		{
+			Meta:  api.Meta{Ident: 2, Start: api.Key("ggg"), End: api.Key("sss")},
+			State: api.NsActive,
+		},
+	})
+	h.add(t, api.Remote{
+		Ident: "bbb",
+		Host:  "host-bbb",
+	}, []api.RangeInfo{
+		{
+			Meta:  api.Meta{Ident: 3, Start: api.Key("sss")},
+			State: api.NsActive,
+		},
+	})
+
+	// TODO: Add some kind of sync method to block until the mirror has fetched
+	//       something (or nothing) from each node.
+	time.Sleep(100 * time.Millisecond)
+
+	res := h.mirror.Find(api.Key("ccc"))
+	assert.DeepEqual(t, []Result{{
+		NodeID:  "aaa",
+		RangeID: 1,
+		State:   api.NsActive,
+	}}, res)
+
+	res = h.mirror.Find(api.Key("hhh"))
+	assert.DeepEqual(t, []Result{{
+		NodeID:  "aaa",
+		RangeID: 2,
+		State:   api.NsActive,
+	}}, res)
+
+	res = h.mirror.Find(api.Key("zzz"))
+	assert.DeepEqual(t, []Result{{
+		NodeID:  "bbb",
+		RangeID: 3,
+		State:   api.NsActive,
+	}}, res)
+}
+
+// -----------------------------------------------------------------------------
+
+type testHarness struct {
+	disc   *mock_disc.Discoverer
+	nodes  map[api.Remote]*nodeServer
+	mirror *Mirror
+}
+
+func setup(t *testing.T) *testHarness {
+	h := &testHarness{
+		disc:  mock_disc.NewDiscoverer(),
+		nodes: map[api.Remote]*nodeServer{},
+	}
+
+	h.mirror = New(h.disc).WithDialler(h.dial) // SUT
+
+	t.Cleanup(func() {
+		// Ignore errors
+		_ = h.mirror.Stop()
+	})
+
+	return h
+}
+
+func (h *testHarness) add(t *testing.T, rem api.Remote, ranges []api.RangeInfo) {
+	ns := newNodeServer(ranges)
+	t.Cleanup(ns.stop)
+	h.nodes[rem] = ns
+	h.disc.Add("node", rem)
+}
+
+func (h *testHarness) dial(ctx context.Context, rem api.Remote) (*grpc.ClientConn, error) {
+	node, ok := h.nodes[rem]
+	if !ok {
+		log.Printf("No such remote: %s", rem.Ident)
+		return nil, fmt.Errorf("No such remote: %s", rem.Ident)
+	}
+
+	return grpc.DialContext(ctx, "", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return node.listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+}
+
+type nodeServer struct {
+	pb.UnimplementedNodeServer
+
+	server   *grpc.Server
+	listener *bufconn.Listener
+	ranges   []api.RangeInfo
+	quit     *sync.WaitGroup
+}
+
+func newNodeServer(ranges []api.RangeInfo) *nodeServer {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	ns := &nodeServer{
+		server:   grpc.NewServer(),
+		listener: bufconn.Listen(1024 * 1024),
+		ranges:   ranges,
+		quit:     wg,
+	}
+
+	pb.RegisterNodeServer(ns.server, ns)
+
+	go func() {
+		if err := ns.server.Serve(ns.listener); err != nil {
+			panic(err)
+		}
+	}()
+
+	return ns
+}
+
+func (ns *nodeServer) stop() {
+	ns.server.Stop()
+	ns.quit.Done()
+}
+
+func (ns *nodeServer) Ranges(req *pb.RangesRequest, stream pb.Node_RangesServer) error {
+	for _, ri := range ns.ranges {
+		stream.Send(&pb.RangesResponse{
+			Meta:  conv.MetaToProto(ri.Meta),
+			State: conv.RemoteStateToProto(ri.State),
+		})
+	}
+
+	ns.quit.Wait()
+
+	return io.EOF
+}

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -26,7 +26,7 @@ func Setup() (*MockNode, *Rangelet) {
 	}
 
 	stor := fake_storage.NewFakeStorage(nil)
-	rglt := NewRangelet(n, nil, stor)
+	rglt := newRangelet(n, stor)
 	rglt.gracePeriod = 10 * time.Millisecond
 	return n, rglt
 }

--- a/pkg/rangelet/server_test.go
+++ b/pkg/rangelet/server_test.go
@@ -1,0 +1,104 @@
+package rangelet
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/adammck/ranger/pkg/api"
+	pb "github.com/adammck/ranger/pkg/proto/gen"
+	"github.com/adammck/ranger/pkg/test/fake_storage"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/testing/protocmp"
+	"gotest.tools/assert"
+)
+
+type rangeInfos map[api.RangeID]*api.RangeInfo
+
+func TestRanges(t *testing.T) {
+	h := setup(t, singleRange())
+	req := &pb.RangesRequest{}
+
+	res, err := h.client.Ranges(h.ctx, req)
+	assert.NilError(t, err)
+
+	r, err := res.Recv()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, &pb.RangesResponse{
+		Meta: &pb.RangeMeta{
+			Ident: 1,
+		},
+		State: pb.RangeNodeState_ACTIVE,
+	}, r, protocmp.Transform())
+
+	err = h.rglt.ForceDrop(1)
+	assert.NilError(t, err)
+
+	r, err = res.Recv()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, &pb.RangesResponse{
+		Meta: &pb.RangeMeta{
+			Ident: 1,
+		},
+		State: pb.RangeNodeState_NOT_FOUND,
+	}, r, protocmp.Transform())
+
+	err = res.CloseSend()
+	assert.NilError(t, err)
+}
+
+type testHarness struct {
+	ctx    context.Context
+	rglt   *Rangelet
+	client pb.NodeClient
+}
+
+func setup(t *testing.T, ri rangeInfos) *testHarness {
+	ctx := context.Background()
+
+	stor := fake_storage.NewFakeStorage(ri)
+	rglt := newRangelet(nil, stor)
+	ns := newNodeServer(rglt) // <-- SUT
+	srv := grpc.NewServer()
+	ns.Register(srv)
+
+	// client
+	conn, closer := nodeServer(ctx, srv)
+	t.Cleanup(closer)
+
+	client := pb.NewNodeClient(conn)
+
+	return &testHarness{
+		ctx:    ctx,
+		rglt:   rglt,
+		client: client,
+	}
+}
+
+func singleRange() rangeInfos {
+	return rangeInfos{
+		1: {
+			Meta:  api.Meta{Ident: 1},
+			State: api.NsActive,
+		},
+	}
+}
+
+// From: https://harrigan.xyz/blog/testing-go-grpc-server-using-an-in-memory-buffer-with-bufconn/
+func nodeServer(ctx context.Context, s *grpc.Server) (*grpc.ClientConn, func()) {
+	listener := bufconn.Listen(1024 * 1024)
+
+	go func() {
+		if err := s.Serve(listener); err != nil {
+			panic(err)
+		}
+	}()
+
+	conn, _ := grpc.DialContext(ctx, "", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+
+	return conn, s.Stop
+}

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -83,7 +83,7 @@ func NewTestNode(ctx context.Context, addr string, rangeInfos map[api.RangeID]*a
 
 	srv := grpc.NewServer()
 	stor := fake_storage.NewFakeStorage(rangeInfos)
-	n.rglt = rangelet.NewRangelet(n, srv, stor)
+	n.rglt = rangelet.New(n, srv, stor)
 
 	// Just for tests.
 	n.rglt.SetGracePeriod(10 * time.Millisecond)


### PR DESCRIPTION
This adds a streaming endpoint to the rangelet (and therefore all nodes) to return the ranges (including metadata and state) currently assigned to the node, and to stream any further changes to them. This is much better for fat clients wanting to look up a range. Currently they have to embed a roster, which polls (slowly) for ranges and loadinfo.

This *might* be a good idea to stream changes to the roster, too, but I'm not crazy about nodes initiating any kinds of communication to the controller. It's safer that when the controller is overworked, it can just slow down and not probe so much.

```console
$ grpcurl -plaintext localhost:5200 ranger.Node.Ranges
{
  "meta": {
    "ident": "1",
    "start": "YmJi",
    "end": "dHR0"
  },
  "state": "LOADING"
}
{
  "meta": {
    "ident": "1",
    "start": "YmJi",
    "end": "dHR0"
  },
  "state": "INACTIVE"
}
{
  "meta": {
    "ident": "1",
    "start": "YmJi",
    "end": "dHR0"
  },
  "state": "ACTIVATING"
}
^C
```

It also adds a `Mirror` package to consume this streaming endpoint. It uses the same pluggable service discovery package as the controller does, which makes it pretty simple to use. It's asynchronous, so always slightly out of date, but it's pretty fast since it uses streaming RPCs and not polling. Basic usage looks like:

```go
disc := consuldisc.NewDiscoverer(consulapi.DefaultConfig())
mir := mirror.New(disc)

// later...
res := mir.Find(api.Key("my-favorite-key"), api.NsActive)
assert.DeepEqual(t, []Result{{
  NodeID:  "aaa",
  RangeID: 1,
  State:   api.NsActive,
}}, res)

// optionally...
con, ok := mir.Conn(res[0].NodeID)
client := pb.NewBlahClient(con)
```

