### PR TITLE
Add distributed cache example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ in collaborating.
 
 ## Examples
 
+- [cache](examples/cache)
 - [key-value store](examples/kv)
 
 ## Interface

--- a/examples/cache/.gitignore
+++ b/examples/cache/.gitignore
@@ -1,0 +1,4 @@
+# binaries
+/cache
+/rangerd
+/rangerctl

--- a/examples/cache/Procfile
+++ b/examples/cache/Procfile
@@ -1,0 +1,2 @@
+controller: ./rangerd -addr "127.0.0.1:$PORT"
+node: ./cache -grpc "127.0.0.1:1$PORT" -http "127.0.0.1:2$PORT"

--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -1,0 +1,5 @@
+# Example: Cache
+
+This is a simple distributed read-through cache using ranger. Send a URL, and it
+will be hashed and routed to a node. That node will fetch and cache it (if it's
+not already cached) and then return it.

--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -1,5 +1,91 @@
 # Example: Cache
 
-This is a simple distributed read-through cache using ranger. Send a URL, and it
-will be hashed and routed to a node. That node will fetch and cache it (if it's
-not already cached) and then return it.
+This is a simple distributed cache using ranger. The work it performs is totally
+pointless and deliberately expensive -- it recursively hashes incoming payloads
+ten million times -- but is cached by key, so subsequent requests for the same
+payload are fast. We can pretend that the workload is doing something expensive
+but useful, like sending some RPCs, searching through a lot of data, or caching
+some data from underlying storage.
+
+This demonstrates the following features:
+
+- **Separate data/control planes**:  
+  Ranger traffic (from controller to node, and between nodes) is exchanged over
+  gRPC, but the service exposes its own endpoint(s) over a separte HTTP server.
+- **Dumb client**:  
+  There's no custom client to send a request; it's just cURL.
+- **Request Forwarding**:  
+  Incoming requests are either handled, or forwarded (via HTTP 302) to the
+  appropriate node. This is accomplished by every node maintaining a mirror of
+  all range assignments.
+- **Stateless**:  
+  Cached data is not moved between nodes when range reassignments happen. It's
+  just thrown away. The rangelet integration is therefore very simple.
+
+## Usage
+
+Start the thing using Foreman:  
+(The port assignments are a huge hack.)
+
+```console
+$ brew services run consul
+==> Successfully ran `consul` (label: homebrew.mxcl.consul)
+$ cd ~/code/src/github.com/adammck/ranger/examples/cache
+$ bin/dev.sh
+18:56:00 controller.1 | started with pid 93093
+18:56:00 node.1       | started with pid 93094
+18:56:00 node.2       | started with pid 93095
+18:56:00 node.3       | started with pid 93096
+18:56:00 controller.1 | listening on: 127.0.0.1:5000
+18:56:00 node.1       | grpc listening on: 127.0.0.1:15100
+18:56:00 node.1       | http listening on: 127.0.0.1:25100
+18:56:00 node.2       | grpc listening on: 127.0.0.1:15101
+18:56:00 node.2       | http listening on: 127.0.0.1:25101
+18:56:00 node.3       | grpc listening on: 127.0.0.1:15102
+18:56:00 node.3       | http listening on: 127.0.0.1:25102
+```
+
+In a separate terminal, send some requests to node 1, which is currently
+assigned the entire keyspace in a single range:
+
+```console
+$ curl -L http://localhost:25100/a
+4851381cac0c5b0c2e4a6c7e5629c6ac6db47f2a15c31d40f242a6be39ffb97d
+
+$ curl -L http://localhost:25100/b
+3adbb65d20ee48ab81fc63063dc2ec38c31c7089782fc6f434627c3829eaf87c
+```
+
+Now send some requests to node 2, which is assigned nothing. It works, because
+the request is forwarded to node 1, as can be seen by showing HTTP headers:
+
+```console
+$ curl -iL http://localhost:25101/c
+HTTP/1.1 302 Found
+Content-Type: text/plain
+Location: http://127.0.0.1:25100/c
+Date: Sun, 27 Nov 2022 00:57:00 GMT
+Content-Length: 0
+
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Server: 127.0.0.1:25100
+Date: Sun, 27 Nov 2022 00:57:00 GMT
+Content-Length: 65
+
+ca4f2be4e4c9604df3b971deae26f077841f0ec34ff9a77a534988c6352566f6
+```
+
+Use
+[rangerctl](https://github.com/adammck/ranger/tree/master/cmd/rangerctl)
+to query the state of the cluster (nodes and range assignments) and initiate
+range operations (moves, splits, joins). This is built by `dev.sh`, so to see
+usage, run:
+
+```console
+$ ./rangerctl
+```
+
+## License
+
+MIT.

--- a/examples/cache/bin/dev.sh
+++ b/examples/cache/bin/dev.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! consul info 1>/dev/null 2>/dev/null; then
+    echo "Error: Consul is not running"
+    exit 1
+fi
+
+go build # cache
+go build "$(dirname "$0")"/../../../cmd/rangerctl
+go build "$(dirname "$0")"/../../../cmd/rangerd
+foreman start -m controller=1,node=3

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/adammck/ranger/pkg/api"
+	"github.com/adammck/ranger/pkg/discovery"
+	consuldisc "github.com/adammck/ranger/pkg/discovery/consul"
+	"github.com/adammck/ranger/pkg/rangelet"
+	"github.com/adammck/ranger/pkg/rangelet/storage/null"
+	consulapi "github.com/hashicorp/consul/api"
+	"google.golang.org/grpc"
+)
+
+type Runner interface {
+	Run(ctx context.Context) error
+}
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func main() {
+	addrGRPC := flag.String("grpc", "localhost:8000", "grpc server")
+	addrHTTP := flag.String("http", "localhost:8001", "http server")
+	flag.Parse()
+
+	// Replace default logger.
+	log.Default().SetOutput(os.Stdout)
+	log.Default().SetPrefix("")
+	log.Default().SetFlags(0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sig
+		cancel()
+	}()
+
+	var cmd Runner
+	var err error
+
+	cmd, err = NewNode(*addrGRPC, *addrHTTP)
+
+	if err != nil {
+		exit(err)
+	}
+
+	err = cmd.Run(ctx)
+	if err != nil {
+		exit(err)
+	}
+}
+
+func exit(err error) {
+	log.Fatalf("Error: %s", err)
+}
+
+// ----
+
+type Node struct {
+	addrGRPC string
+	addrHTTP string
+
+	// Ranger stuff
+	gsrv *grpc.Server
+	rglt *rangelet.Rangelet
+	disc discovery.Discoverable
+
+	// Cache stuff
+	hsrv  *http.Server
+	cache map[string][32]byte
+}
+
+func NewNode(addrGRPC, addrHTTP string) (*Node, error) {
+	var opts []grpc.ServerOption
+	srv := grpc.NewServer(opts...)
+
+	disc, err := consuldisc.New("node", addrGRPC, consulapi.DefaultConfig(), srv)
+	if err != nil {
+		return nil, err
+	}
+
+	n := &Node{
+		addrGRPC: addrGRPC,
+		addrHTTP: addrHTTP,
+		gsrv:     srv,
+		disc:     disc,
+		cache:    map[string][32]byte{},
+	}
+
+	n.rglt = rangelet.NewRangelet(n, srv, &null.NullStorage{})
+
+	n.hsrv = &http.Server{
+		Addr:    addrHTTP,
+		Handler: n,
+	}
+
+	return n, nil
+}
+
+func (n *Node) Run(ctx context.Context) error {
+
+	// For the gRPC server.
+	lisg, err := net.Listen("tcp", n.addrGRPC)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("grpc listening on: %s", n.addrGRPC)
+
+	// For the HTTP server
+	lish, err := net.Listen("tcp", n.addrHTTP)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("http listening on: %s", n.addrHTTP)
+
+	// Start the gRPC server in a background routine.
+	errChan := make(chan error)
+	go func() {
+		err := n.gsrv.Serve(lisg)
+		if err != nil {
+			errChan <- err
+		}
+		close(errChan)
+	}()
+
+	// Register with service discovery, so rangerd can find us.
+	err = n.disc.Start()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		n.hsrv.Serve(lish)
+	}()
+
+	// Block until context is cancelled, indicating that caller wants shutdown.
+	<-ctx.Done()
+
+	// Let in-flight RPCs finish and then stop. errChan will contain the error
+	// returned by srv.Serve (above) or be closed with no error.
+	n.gsrv.GracefulStop()
+	err = <-errChan
+	if err != nil {
+		log.Printf("error from srv.Serve: %v", err)
+		return err
+	}
+
+	// Remove ourselves from service discovery. Not strictly necessary, but lets
+	// the other nodes respond quicker.
+	err = n.disc.Stop()
+	if err != nil {
+		return err
+	}
+
+	// Gracefully stop the HTTP server.
+	ctx2, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	n.hsrv.Shutdown(ctx2)
+	cancel()
+
+	return nil
+}
+
+// Control plane
+
+func (n *Node) GetLoadInfo(rID api.RangeID) (api.LoadInfo, error) {
+	return api.LoadInfo{}, nil
+}
+
+func (n *Node) PrepareAddRange(rm api.Meta, parents []api.Parent) error {
+	return nil
+}
+
+func (n *Node) AddRange(rID api.RangeID) error {
+	return nil
+}
+
+func (n *Node) PrepareDropRange(rID api.RangeID) error {
+	return nil
+}
+
+func (n *Node) DropRange(rID api.RangeID) error {
+	return nil
+}
+
+// Data plane
+
+func (n *Node) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+
+	k := r.URL.Path
+	k = strings.TrimLeft(k, "/")
+
+	_, ok := n.rglt.Find(api.Key(k))
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, "not found.")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	// TODO: Block if same key is being concurrently hashed.
+	h, ok := n.cache[k]
+	if !ok {
+		h = hash(k)
+		n.cache[k] = h
+	}
+
+	fmt.Fprintln(w, h)
+}
+
+func hash(input string) [32]byte {
+	x := sha256.Sum256([]byte(input))
+
+	for i := 0; i < 10_000_000; i++ {
+		x = sha256.Sum256(x[:])
+	}
+
+	return x
+}

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"log"
@@ -19,9 +20,11 @@ import (
 	"github.com/adammck/ranger/pkg/discovery"
 	consuldisc "github.com/adammck/ranger/pkg/discovery/consul"
 	"github.com/adammck/ranger/pkg/rangelet"
+	"github.com/adammck/ranger/pkg/rangelet/mirror"
 	"github.com/adammck/ranger/pkg/rangelet/storage/null"
 	consulapi "github.com/hashicorp/consul/api"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type Runner interface {
@@ -56,7 +59,6 @@ func main() {
 	var err error
 
 	cmd, err = NewNode(*addrGRPC, *addrHTTP)
-
 	if err != nil {
 		exit(err)
 	}
@@ -81,6 +83,7 @@ type Node struct {
 	gsrv *grpc.Server
 	rglt *rangelet.Rangelet
 	disc discovery.Discoverable
+	mir  *mirror.Mirror
 
 	// Cache stuff
 	hsrv  *http.Server
@@ -91,20 +94,37 @@ func NewNode(addrGRPC, addrHTTP string) (*Node, error) {
 	var opts []grpc.ServerOption
 	srv := grpc.NewServer(opts...)
 
+	// To make ourselves discoverable by the controller and other nodes. This is
+	// unnecessary in environments with ambient service discovery.
 	disc, err := consuldisc.New("node", addrGRPC, consulapi.DefaultConfig(), srv)
 	if err != nil {
 		return nil, err
 	}
+
+	// The mirror watches range assignments (to any node) so that this node can
+	// handle any request, not just those contained by ranges assigned to it.
+	// For those not assigned, the mirror can be queried to find the relevant
+	// nodes, and forward the request there. This allows clients to send their
+	// requests to any arbitrary node, and not have to perform range lookup
+	// themselves. This is especially useful for short-lived clients.
+	discoverer, err := consuldisc.NewDiscoverer(consulapi.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+	mir := mirror.New(discoverer).WithDialler(func(ctx context.Context, rem api.Remote) (*grpc.ClientConn, error) {
+		return grpc.DialContext(ctx, rem.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	})
 
 	n := &Node{
 		addrGRPC: addrGRPC,
 		addrHTTP: addrHTTP,
 		gsrv:     srv,
 		disc:     disc,
+		mir:      mir,
 		cache:    map[string][32]byte{},
 	}
 
-	n.rglt = rangelet.NewRangelet(n, srv, &null.NullStorage{})
+	n.rglt = rangelet.New(n, srv, &null.NullStorage{})
 
 	n.hsrv = &http.Server{
 		Addr:    addrHTTP,
@@ -149,25 +169,21 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 
 	go func() {
-		n.hsrv.Serve(lish)
+		err := n.hsrv.Serve(lish)
+		if err != nil && err != http.ErrServerClosed {
+			log.Printf("error from hsrv.Serve: %v", err)
+		}
 	}()
 
 	// Block until context is cancelled, indicating that caller wants shutdown.
 	<-ctx.Done()
 
-	// Let in-flight RPCs finish and then stop. errChan will contain the error
-	// returned by srv.Serve (above) or be closed with no error.
-	n.gsrv.GracefulStop()
+	// Terminate in-flight RPCs and stop the gRPC server. errChan will contain
+	// the error returned by gsrv.Serve (above) or be closed with no error.
+	n.gsrv.Stop()
 	err = <-errChan
 	if err != nil {
-		log.Printf("error from srv.Serve: %v", err)
-		return err
-	}
-
-	// Remove ourselves from service discovery. Not strictly necessary, but lets
-	// the other nodes respond quicker.
-	err = n.disc.Stop()
-	if err != nil {
+		log.Printf("error from gsrv.Serve: %v", err)
 		return err
 	}
 
@@ -175,6 +191,20 @@ func (n *Node) Run(ctx context.Context) error {
 	ctx2, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	n.hsrv.Shutdown(ctx2)
 	cancel()
+
+	// Stop range assignement mirror. It's useless now that we are not receiving
+	// any more requests.
+	err = n.mir.Stop()
+	if err != nil {
+		log.Printf("error from Mirror.Stop: %v", err)
+	}
+
+	// Remove ourselves from service discovery. Not strictly necessary, but lets
+	// the other nodes respond quicker versus us disappearing and timing out.
+	err = n.disc.Stop()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -208,15 +238,33 @@ func (n *Node) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	k := r.URL.Path
 	k = strings.TrimLeft(k, "/")
+	ak := api.Key(k)
 
-	_, ok := n.rglt.Find(api.Key(k))
+	_, ok := n.rglt.Find(ak)
 	if !ok {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, "not found.")
+		// The key is not assigned to this node, so we will helpfully redirect
+		// the caller to a node which it *is* assigned to, which we know via the
+		// range assignment mirror.
+		res := n.mir.Find(ak, api.NsActive)
+		if len(res) == 0 {
+
+			// No results! The range is either unassigned or our mirror is out
+			// of date. Either way, return an error so the client can retry
+			// against a different node.
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintln(w, "not found.")
+			return
+		}
+
+		// Construct the HTTP (data-plane) address fo the node which we believe
+		// the key is assigned to, and redirect to it. The caller might follow
+		// this automatically. We could alteratively proxy the request to the
+		// relevant node (like TCube cacheservers did/do), but this is just a
+		// simple demo.
+		url := fmt.Sprintf("http://%s/%s", dataAddr(res[0].Remote), k)
+		http.Redirect(w, r, url, http.StatusFound)
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
 
 	// TODO: Block if same key is being concurrently hashed.
 	h, ok := n.cache[k]
@@ -225,9 +273,14 @@ func (n *Node) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		n.cache[k] = h
 	}
 
-	fmt.Fprintln(w, h)
+	w.Header().Set("Server", n.hsrv.Addr)
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, hex.EncodeToString(h[:]))
 }
 
+// hash performs a lot of useless work, and then returns a hash of the given
+// input string. This cache example uses this to represent some expensive but
+// arbitrary data which benefits from being cached.
 func hash(input string) [32]byte {
 	x := sha256.Sum256([]byte(input))
 
@@ -236,4 +289,35 @@ func hash(input string) [32]byte {
 	}
 
 	return x
+}
+
+// dataAddr returns the remote addr for the given remote, but with the leading 1
+// of the port replaced with a 2. This is of course a terrible hack! But rangerd
+// has no clue about the port conventions of this cache service, and the mirror
+// currently provides no way to smuggle that info across the wire.
+//
+// Ideally the rangelet would accept some arbitrary blob of bytes (like an empty
+// interface, but serializable) which could be included with responses to probes
+// and range assignments, like "extra info about this node". Obviously services
+// would have to deserialize it themselves.
+//
+// In the case of this service, the extra payload would be simply:
+//   type CacheNodeInfo struct {
+// 	   dataPort int
+//   }
+//
+// More complex services may smuggle signals like ingestion or replication lag,
+// which clients then use to decide which result to use, although those examples
+// sound more like per-range info than per-node...
+//
+// Services can already, of course, provide endpoints to exchange info entirely
+// outside of ranger. But it feels unnecessarily boiler-platey to provide a gRPC
+// endpoint just to ask "what is your HTTP port?".
+func dataAddr(rem api.Remote) string {
+	cp := fmt.Sprintf("%d", rem.Port)
+	if cp[0] != '1' {
+		panic(fmt.Sprintf("not a control plane port: %d", rem.Port))
+	}
+
+	return fmt.Sprintf("%s:2%s", rem.Host, cp[1:])
 }


### PR DESCRIPTION
This is a very verbose example of a totally different approach (versus the kv example) to using Ranger. It vaguely superficially resembles a certain cacheserver job of a certain distributed time-series store. It highlights at least one missing feature, but is otherwise a pretty neat example of what's possible.