### PR TITLE
Straighten out command terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ in collaborating.
 
 Services implement [rangelet.Node](pkg/api/node.go):
 
-- `GetLoadInfo(rID RangeID) LoadInfo`
-- `PrepareAddRange(rm RangeMeta, parents []Parent) error`
-- `AddRange(rid RangeID) error`
-- `PrepareDropRange(rid RangeID) error`
-- `DropRange(rid RangeID) error`
+- `GetLoadInfo(RangeID) (LoadInfo, error)`
+- `Prepare(RangeMeta, []Parent) error`
+- `Activate(RangeID) error`
+- `Deactivate(RangeID) error`
+- `Drop(RangeID) error`
 
 This is a Go interface, but it's all gRPC+protobufs under the hood. There are no
 other implementations today, but it's a goal to avoid doing anything which would

--- a/cmd/dumbbal/main.go
+++ b/cmd/dumbbal/main.go
@@ -91,7 +91,7 @@ func main() {
 			}
 		}
 
-		// Ignore ranges with no ready placements.
+		// Ignore ranges with no active placements.
 		if len(placements) == 0 {
 			continue
 		}

--- a/docs/join.md
+++ b/docs/join.md
@@ -3,14 +3,14 @@
 When two ranges (1, 2) are assigned to nodes (a, b), and we want to join them
 into a single range (3) assined to a different node (c), we **join** them.
 
-1. PrepareAddRange(c, 3)
-2. PrepareDropRange
-   1. PrepareDropRange(a, 1)
-   2. PrepareDropRange(a, 2)
-3. AddRange(c, 3)
-4. DropRange
-   1. DropRange(a, 1)
-   2. DropRange(a, 2)
+1. Prepare(c, 3)
+2. Deactivate
+   1. Deactivate(a, 1)
+   2. Deactivate(a, 2)
+3. Activate(c, 3)
+4. Drop
+   1. Drop(a, 1)
+   2. Drop(a, 2)
 
 [_TestJoin_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoin)
 
@@ -18,72 +18,72 @@ into a single range (3) assined to a different node (c), we **join** them.
 
 If step 1 fails, just abort the join:
 
-1. <strike>PrepareAddRange(c, 3)</strike>
+1. <strike>Prepare(c, 3)</strike>
 
-[_TestJoinFailure_PrepareAddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_PrepareAddRange)
-
----
-
-If step 2 fails, revert any source placements which suceeded prepareDrop back to
-ready, drop the destination placement, and abort the join:
-
-1. PrepareAddRange(c, 3)
-2. <strike>PrepareDropRange</strike>
-   1. <strike>PrepareDropRange(a, 1)</strike>
-   2. <strike>PrepareDropRange(a, 2)</strike>
-3. DropRange(c, 3)
-
-or
-
-1. PrepareAddRange(c, 3)
-2. <strike>PrepareDropRange</strike>
-   1. <strike>PrepareDropRange(a, 1)</strike>
-   2. PrepareDropRange(a, 2)
-3. AddRange
-   1. AddRange(a, 2)
-4. DropRange(c, 3)
-
-or
-
-1. PrepareAddRange(c, 3)
-2. <strike>PrepareDropRange</strike>
-   1. PrepareDropRange(a, 1)
-   2. <strike>PrepareDropRange(a, 2)</strike>
-3. AddRange
-   1. AddRange(a, 1)
-4. DropRange(c, 3)
-
-[_TestJoinFailure_PrepareDropRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_PrepareDropRange)
+[_TestJoinFailure_Prepare_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_Prepare)
 
 ---
 
-If step 3 fails, revert source placements back to ready, drop the destination
-placement, and abort the join:
+If step 2 fails, reactivate any of the source placements which were deactivated,
+drop the destination placement, and abort the join:
 
-1. PrepareAddRange(c, 3)
-2. PrepareDropRange
-   1. PrepareDropRange(a, 1)
-   2. PrepareDropRange(a, 2)
-3. <strike>AddRange(c, 3)</strike>
-4. AddRange
-   1. AddRange(a, 1)
-   2. AddRange(a, 2)
-4. DropRange(c, 3)
+1. Prepare(c, 3)
+2. <strike>Deactivate</strike>
+   1. <strike>Deactivate(a, 1)</strike>
+   2. <strike>Deactivate(a, 2)</strike>
+3. Drop(c, 3)
 
-[_TestJoinFailure_AddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_AddRange)
+or
+
+1. Prepare(c, 3)
+2. <strike>Deactivate</strike>
+   1. <strike>Deactivate(a, 1)</strike>
+   2. Deactivate(a, 2)
+3. Activate
+   1. Activate(a, 2)
+4. Drop(c, 3)
+
+or
+
+1. Prepare(c, 3)
+2. <strike>Deactivate</strike>
+   1. Deactivate(a, 1)
+   2. <strike>Deactivate(a, 2)</strike>
+3. Activate
+   1. Activate(a, 1)
+4. Drop(c, 3)
+
+[_TestJoinFailure_Deactivate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_Deactivate)
+
+---
+
+If step 3 fails, reactivate source placements, drop the destination placement,
+and abort the join:
+
+1. Prepare(c, 3)
+2. Deactivate
+   1. Deactivate(a, 1)
+   2. Deactivate(a, 2)
+3. <strike>Activate(c, 3)</strike>
+4. Activate
+   1. Activate(a, 1)
+   2. Activate(a, 2)
+4. Drop(c, 3)
+
+[_TestJoinFailure_Activate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_Activate)
 
 ---
 
 If step 4 fails, do nothing but keep trying forever until both source placements
 are dropped:
 
-1. PrepareAddRange(c, 3)
-2. PrepareDropRange
-   1. PrepareDropRange(a, 1)
-   2. PrepareDropRange(a, 2)
-3. AddRange(c, 3)
-4. <strike>DropRange</strike>
-   1. <strike>DropRange(a, 1)</strike>
-   2. DropRange(a, 2)
+1. Prepare(c, 3)
+2. Deactivate
+   1. Deactivate(a, 1)
+   2. Deactivate(a, 2)
+3. Activate(c, 3)
+4. <strike>Drop</strike>
+   1. <strike>Drop(a, 1)</strike>
+   2. Drop(a, 2)
 
-[_TestJoinFailure_DropRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_DropRange)
+[_TestJoinFailure_Drop_](https://cs.github.com/adammck/ranger?q=symbol%3ATestJoinFailure_Drop)

--- a/docs/move.md
+++ b/docs/move.md
@@ -3,10 +3,10 @@
 When a range is assigned to a node (a), and we want it to be assigned to a
 different node (b), we **move** it.
 
-1. PrepareAddRange(b)
-2. PrepareDropRange(a)
-3. AddRange(b)
-4. DropRange(a)
+1. Prepare(b)
+2. Deactivate(a)
+3. Activate(b)
+4. Drop(a)
 
 [_TestMove_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMove)
 
@@ -14,40 +14,40 @@ different node (b), we **move** it.
 
 If step 1 fails, abort the move:
 
-1. <strike>PrepareAddRange(b)</strike>
+1. <strike>Prepare(b)</strike>
 
-[_TestMoveFailure_PrepareAddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_PrepareAddRange)
+[_TestMoveFailure_Prepare_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_Prepare)
 
 ---
 
 If step 2 fails, drop the destination placement and abort the move:
 
-1. PrepareAddRange(b)
-2. <strike>PrepareDropRange(a)</strike>
-3. DropRange(b)
+1. Prepare(b)
+2. <strike>Deactivate(a)</strike>
+3. Drop(b)
 
-[_TestMoveFailure_PrepareDropRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_PrepareDropRange)
+[_TestMoveFailure_Deactivate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_Deactivate)
 
 ---
 
-If step 3 fails, revert the source range to ready, drop the destination
+If step 3 fails, reactivate the source placement, drop the destination
 placement, and abort the move:
 
-1. PrepareAddRange(b)
-2. PrepareDropRange(a)
-3. <strike>AddRange(b)</strike>
-4. AddRange(a)
-5. DropRange(b)
+1. Prepare(b)
+2. Deactivate(a)
+3. <strike>Activate(b)</strike>
+4. Activate(a)
+5. Drop(b)
 
-[_TestMoveFailure_AddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_AddRange)
+[_TestMoveFailure_Activate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_Activate)
 
 ---
 
 If step 4 fails, do nothing but keep trying forever:
 
-1. PrepareAddRange(b)
-2. PrepareDropRange(a)
-3. AddRange(b)
-4. <strike>DropRange(a)</strike>
+1. Prepare(b)
+2. Deactivate(a)
+3. Activate(b)
+4. <strike>Drop(a)</strike>
 
-[_TestMoveFailure_DropRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_DropRange)
+[_TestMoveFailure_Drop_](https://cs.github.com/adammck/ranger?q=symbol%3ATestMoveFailure_Drop)

--- a/docs/place.md
+++ b/docs/place.md
@@ -2,8 +2,8 @@
 
 When a range isn't assigned to any node, we **place** it on a node (a).
 
-1. PrepareAddRange(a)
-2. AddRange(a)
+1. Prepare(a)
+2. Activate(a)
 
 [_TestPlace_](https://cs.github.com/adammck/ranger?q=symbol%3ATestPlace)
 
@@ -11,16 +11,16 @@ When a range isn't assigned to any node, we **place** it on a node (a).
 
 If step 1 fails, abort the place:
 
-1. <strike>PrepareAddRange(a)</strike>
+1. <strike>Prepare(a)</strike>
 
-[_TestPlaceFailure_PrepareAddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestPlaceFailure_PrepareAddRange)
+[_TestPlaceFailure_Prepare_](https://cs.github.com/adammck/ranger?q=symbol%3ATestPlaceFailure_Prepare)
 
 ---
 
 If step 2 fails, drop the placement and abort the place:
 
-1. PrepareAddRange(a)
-2. <strike>AddRange(a)</strike>
-3. DropRange(a)
+1. Prepare(a)
+2. <strike>Activate(a)</strike>
+3. Drop(a)
 
-[_TestPlaceFailure_AddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestPlaceFailure_AddRange)
+[_TestPlaceFailure_Activate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestPlaceFailure_Activate)

--- a/docs/split.md
+++ b/docs/split.md
@@ -3,124 +3,124 @@
 When a range (1) is assigned to a node (a), and we want to split it into two
 separate ranges (2, 3) assigned to different nodes (b, c), we **split** it.
 
-1. PrepareAddRange
-   1. PrepareAddRange(b, 2)
-   2. PrepareAddRange(c, 3)
-2. PrepareDropRange(a, 1)
-3. AddRange
-   1. AddRange(b, 2)
-   2. AddRange(c, 3)
-4. DropRange(a, 1)
+1. Prepare
+   1. Prepare(b, 2)
+   2. Prepare(c, 3)
+2. Deactivate(a, 1)
+3. Activate
+   1. Activate(b, 2)
+   2. Activate(c, 3)
+4. Drop(a, 1)
 
 [_TestSplit_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplit)
 
 ## Failures
 
-If any of the PrepareAddRange commands in step 1 fail, just destroy the failed
+If any of the Prepare commands in step 1 fail, just destroy the failed
 placement(s) and try again on some other node. The predecessor range is still
-Ready, so there is no particular harm in waiting while we try again.
+active, so there is no particular harm in waiting while we try again.
 
-1. <strike>PrepareAddRange</strike>
-   1. <strike>PrepareAddRange(b, 2)</strike>
-   2. <strike>PrepareAddRange(c, 3)</strike>
-1. PrepareAddRange (retry)
-   1. PrepareAddRange(d, 2)
-   2. PrepareAddRange(e, 3)
-
-or
-
-1. <strike>PrepareAddRange</strike>
-   1. <strike>PrepareAddRange(b, 2)</strike>
-   2. PrepareAddRange(c, 3)
-2. PrepareAddRange (retry)
-   1. PrepareAddRange(d, 2)
+1. <strike>Prepare</strike>
+   1. <strike>Prepare(b, 2)</strike>
+   2. <strike>Prepare(c, 3)</strike>
+1. Prepare (retry)
+   1. Prepare(d, 2)
+   2. Prepare(e, 3)
 
 or
 
-1. <strike>PrepareAddRange</strike>
-   1. PrepareAddRange(b, 2)
-   2. <strike>PrepareAddRange(c, 3)</strike>
-2. PrepareAddRange (retry)
-   1. PrepareAddRange(d, 3)
+1. <strike>Prepare</strike>
+   1. <strike>Prepare(b, 2)</strike>
+   2. Prepare(c, 3)
+2. Prepare (retry)
+   1. Prepare(d, 2)
 
-[_TestSplitFailure_PrepareAddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_PrepareAddRange)
+or
+
+1. <strike>Prepare</strike>
+   1. Prepare(b, 2)
+   2. <strike>Prepare(c, 3)</strike>
+2. Prepare (retry)
+   1. Prepare(d, 3)
+
+[_TestSplitFailure_Prepare_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_Prepare)
 
 Note that cancellation isn't currently part of the Rangelet API (because the
 command methods don't include a context param), so we have to dumbly wait until
-both sides complete their PrepareAddRange before we can proceed, even if one
-fails fast. Not a huge deal, but pointless work.
+both sides complete their Prepare before we can proceed, even if one fails fast.
+Not a huge deal, but pointless work.
 
 ---
 
-If step 2 fails -- the source placement failed to PrepareDropRange -- just retry
+If step 2 fails -- the source placement failed to Deactivate -- just retry
 forever (and probably alert an operator). This isn't an emergency (the source
 placement is still ready), but indicates that something is quite broken.
 
-1. PrepareAddRange
-   1. PrepareAddRange(b, 2)
-   2. PrepareAddRange(c, 3)
-2. <strike>PrepareDropRange(a, 1)</strike>
-3. PrepareDropRange(a, 1) (retry)
+1. Prepare
+   1. Prepare(b, 2)
+   2. Prepare(c, 3)
+2. <strike>Deactivate(a, 1)</strike>
+3. Deactivate(a, 1) (retry)
 
 
-[_TestSplitFailure_PrepareDropRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_PrepareDropRange)
+[_TestSplitFailure_Deactivate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_Deactivate)
 
 ---
 
-If step 3 fails, prepareDrop any destination placements which became ready (i.e.
-the ones which _didn't_ fail), revert the source placement to ready, drop the
-placements which failed to become ready, and retry their placement.
+If step 3 fails, deactivate any destination placements which became ready (i.e.
+the ones which _didn't_ fail), reactivate the source placement, drop the
+placements which failed to activate, and retry their placement.
 
-1. PrepareAddRange
-   1. PrepareAddRange(b, 2)
-   2. PrepareAddRange(c, 3)
-2. PrepareDropRange(a, 1)
-3. <strike>AddRange</strike>
-   1. <strike>AddRange(b, 2)</strike>
-   2. <strike>AddRange(c, 3)</strike>
-4. AddRange(a, 1)
-5. DropRange
-   1. DropRange(b, 2)
-   2. DropRange(c, 3)
-6. PrepareAddRange (retry)
-   1. PrepareAddRange(d, 2)
-   2. PrepareAddRange(e, 3)
-
-or
-
-1. PrepareAddRange
-   1. PrepareAddRange(b, 2)
-   2. PrepareAddRange(c, 3)
-2. PrepareDropRange(a, 1)
-3. <strike>AddRange</strike>
-   1. <strike>AddRange(b, 2)</strike>
-   2. AddRange(c, 3)
-4. PrepareDropRange
-   1. PrepareDropRange(c, 3)
-5. AddRange(a, 1)
-6. DropRange
-   1. DropRange(b, 2)
-7. PrepareAddRange (retry)
-   1. PrepareAddRange(d, 2)
+1. Prepare
+   1. Prepare(b, 2)
+   2. Prepare(c, 3)
+2. Deactivate(a, 1)
+3. <strike>Activate</strike>
+   1. <strike>Activate(b, 2)</strike>
+   2. <strike>Activate(c, 3)</strike>
+4. Activate(a, 1)
+5. Drop
+   1. Drop(b, 2)
+   2. Drop(c, 3)
+6. Prepare (retry)
+   1. Prepare(d, 2)
+   2. Prepare(e, 3)
 
 or
 
-1. PrepareAddRange
-   1. PrepareAddRange(b, 2)
-   2. PrepareAddRange(c, 3)
-2. PrepareDropRange(a, 1)
-3. <strike>AddRange</strike>
-   1. AddRange(b, 2)
-   2. <strike>AddRange(c, 3)</strike>
-4. PrepareDropRange
-   1. PrepareDropRange(b, 2)
-5. AddRange(a, 1)
-6. DropRange
-   1. DropRange(c, 3)
-7. PrepareAddRange (retry)
-   1. PrepareAddRange(c, 3)
+1. Prepare
+   1. Prepare(b, 2)
+   2. Prepare(c, 3)
+2. Deactivate(a, 1)
+3. <strike>Activate</strike>
+   1. <strike>Activate(b, 2)</strike>
+   2. Activate(c, 3)
+4. Deactivate
+   1. Deactivate(c, 3)
+5. Activate(a, 1)
+6. Drop
+   1. Drop(b, 2)
+7. Prepare (retry)
+   1. Prepare(d, 2)
 
-[_TestSplitFailure_AddRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_AddRange)
+or
+
+1. Prepare
+   1. Prepare(b, 2)
+   2. Prepare(c, 3)
+2. Deactivate(a, 1)
+3. <strike>Activate</strike>
+   1. Activate(b, 2)
+   2. <strike>Activate(c, 3)</strike>
+4. Deactivate
+   1. Deactivate(b, 2)
+5. Activate(a, 1)
+6. Drop
+   1. Drop(c, 3)
+7. Prepare (retry)
+   1. Prepare(c, 3)
+
+[_TestSplitFailure_Activate_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_Activate)
 
 This one is probably the most complex to recover from.
 
@@ -128,13 +128,13 @@ This one is probably the most complex to recover from.
 
 If step 4 fails, do nothing but keep trying forever:
 
-1. PrepareAddRange
-   1. PrepareAddRange(b, 2)
-   2. PrepareAddRange(c, 3)
-2. PrepareDropRange(a, 1)
-3. AddRange
-   1. AddRange(b, 2)
-   2. AddRange(c, 3)
-4. <strike>DropRange(a, 1)</strike>
+1. Prepare
+   1. Prepare(b, 2)
+   2. Prepare(c, 3)
+2. Deactivate(a, 1)
+3. Activate
+   1. Activate(b, 2)
+   2. Activate(c, 3)
+4. <strike>Drop(a, 1)</strike>
 
-[_TestSplitFailure_DropRange_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_DropRange)
+[_TestSplitFailure_Drop_](https://cs.github.com/adammck/ranger?q=symbol%3ATestSplitFailure_Drop)

--- a/docs/split.md
+++ b/docs/split.md
@@ -54,7 +54,7 @@ Not a huge deal, but pointless work.
 
 If step 2 fails -- the source placement failed to Deactivate -- just retry
 forever (and probably alert an operator). This isn't an emergency (the source
-placement is still ready), but indicates that something is quite broken.
+placement is still active), but indicates that something is quite broken.
 
 1. Prepare
    1. Prepare(b, 2)
@@ -67,7 +67,7 @@ placement is still ready), but indicates that something is quite broken.
 
 ---
 
-If step 3 fails, deactivate any destination placements which became ready (i.e.
+If step 3 fails, deactivate any destination placements which became active (i.e.
 the ones which _didn't_ fail), reactivate the source placement, drop the
 placements which failed to activate, and retry their placement.
 

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -219,7 +219,7 @@ func (n *Node) Prepare(rm api.Meta, parents []api.Parent) error {
 	return nil
 }
 
-func (n *Node) AddRange(rID api.RangeID) error {
+func (n *Node) Activate(rID api.RangeID) error {
 	return nil
 }
 

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -215,7 +215,7 @@ func (n *Node) GetLoadInfo(rID api.RangeID) (api.LoadInfo, error) {
 	return api.LoadInfo{}, nil
 }
 
-func (n *Node) PrepareAddRange(rm api.Meta, parents []api.Parent) error {
+func (n *Node) Prepare(rm api.Meta, parents []api.Parent) error {
 	return nil
 }
 

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -223,7 +223,7 @@ func (n *Node) AddRange(rID api.RangeID) error {
 	return nil
 }
 
-func (n *Node) PrepareDropRange(rID api.RangeID) error {
+func (n *Node) Deactivate(rID api.RangeID) error {
 	return nil
 }
 

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -227,7 +227,7 @@ func (n *Node) Deactivate(rID api.RangeID) error {
 	return nil
 }
 
-func (n *Node) DropRange(rID api.RangeID) error {
+func (n *Node) Drop(rID api.RangeID) error {
 	return nil
 }
 

--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -44,8 +44,8 @@ func (n *Node) GetLoadInfo(rID api.RangeID) (api.LoadInfo, error) {
 	}, nil
 }
 
-// PrepareAddRange: Create the range, but don't do anything with it yet.
-func (n *Node) PrepareAddRange(rm api.Meta, parents []api.Parent) error {
+// Prepare: Create the range, but don't do anything with it yet.
+func (n *Node) Prepare(rm api.Meta, parents []api.Parent) error {
 	if err := n.performChaos(); err != nil {
 		return err
 	}

--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -94,10 +94,10 @@ func (n *Node) AddRange(rID api.RangeID) error {
 	return nil
 }
 
-// PrepareDropRange: Disable writes to the range, because we're about to move
-// it and I don't have the time to implement something better today. In this
-// example, keys are writable on exactly one node. (Or zero, during failures!)
-func (n *Node) PrepareDropRange(rID api.RangeID) error {
+// Deactivate: Disable writes to the range, because we're about to move it and I
+// don't have the time to implement something better today. In this example,
+// keys are writable on exactly one node. (Or zero, during failures!)
+func (n *Node) Deactivate(rID api.RangeID) error {
 	if err := n.performChaos(); err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (n *Node) PrepareDropRange(rID api.RangeID) error {
 
 	r, ok := n.ranges[rID]
 	if !ok {
-		panic("rangelet called PrepareDropRange with unknown range!")
+		panic("rangelet called Deactivate with unknown range!")
 	}
 
 	// Prevent further writes to the range.

--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -116,8 +116,8 @@ func (n *Node) Deactivate(rID api.RangeID) error {
 	return nil
 }
 
-// DropRange: Discard the range.
-func (n *Node) DropRange(rID api.RangeID) error {
+// Drop: Discard the range.
+func (n *Node) Drop(rID api.RangeID) error {
 	if err := n.performChaos(); err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (n *Node) DropRange(rID api.RangeID) error {
 
 	_, ok := n.ranges[rID]
 	if !ok {
-		panic("rangelet called DropRange with unknown range!")
+		panic("rangelet called Drop with unknown range!")
 	}
 
 	delete(n.ranges, rID)

--- a/examples/kv/pkg/node/control.go
+++ b/examples/kv/pkg/node/control.go
@@ -59,7 +59,7 @@ func (n *Node) Prepare(rm api.Meta, parents []api.Parent) error {
 	}
 
 	// TODO: Ideally we would perform most of the fetch here, and only exchange
-	//       the delta (keys which have changed since then) in AddRange.
+	//       the delta (keys which have changed since then) in Activate.
 
 	n.ranges[rm.Ident] = &Range{
 		data:     map[string][]byte{},
@@ -70,8 +70,8 @@ func (n *Node) Prepare(rm api.Meta, parents []api.Parent) error {
 	return nil
 }
 
-// AddRange:
-func (n *Node) AddRange(rID api.RangeID) error {
+// Activate:
+func (n *Node) Activate(rID api.RangeID) error {
 	if err := n.performChaos(); err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (n *Node) AddRange(rID api.RangeID) error {
 	r, ok := n.ranges[rID]
 	n.rangesMu.RUnlock()
 	if !ok {
-		panic("rangelet called AddRange with unknown range!")
+		panic("rangelet called Activate with unknown range!")
 	}
 
 	err := r.fetcher.Fetch(r)

--- a/examples/kv/pkg/node/fetcher.go
+++ b/examples/kv/pkg/node/fetcher.go
@@ -27,7 +27,7 @@ func newFetcher(rm api.Meta, parents []api.Parent) *fetcher {
 
 	// If this is a range move, we can just fetch the whole thing from a single
 	// node. Writes to that node will be disabled (via Deactivate) before the
-	// fetch occurs (via AddRange).
+	// fetch occurs (via Activate).
 
 	for _, par := range parents {
 		for _, plc := range par.Placements {

--- a/examples/kv/pkg/node/fetcher.go
+++ b/examples/kv/pkg/node/fetcher.go
@@ -26,8 +26,8 @@ func newFetcher(rm api.Meta, parents []api.Parent) *fetcher {
 	srcs := []src{}
 
 	// If this is a range move, we can just fetch the whole thing from a single
-	// node. Writes to that node will be disabled (via PrepareDropRange) before
-	// the fetch occurs (via AddRange).
+	// node. Writes to that node will be disabled (via Deactivate) before the
+	// fetch occurs (via AddRange).
 
 	for _, par := range parents {
 		for _, plc := range par.Placements {

--- a/examples/kv/test/node.bats
+++ b/examples/kv/test/node.bats
@@ -84,8 +84,8 @@ teardown() {
     assert_line -n 1 '  Code: FailedPrecondition'
     assert_line -n 2 '  Message: can only dump ranges in the TAKEN state'
 
-    # Take the range from node 1.
-    run bin/client.sh 8001 ranger.Node.Take '{"range": {"key": 1}}'
+    # Deactivate the range from node 1.
+    run bin/client.sh 8001 ranger.Node.Deactivate '{"range": {"key": 1}}'
     assert_success
 
     # Try to dump again. Success!
@@ -102,11 +102,11 @@ teardown() {
 
     # ---- setup
 
-    # Prepare the range [a,b) on node 1, Put some keys, and Take it.
+    # Prepare the range [a,b) on node 1, Put some keys, and Deactivate it.
     r1='{"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}'
     bin/client.sh 8001 ranger.Node.Prepare '{"range": '"$r1"'}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a'", "value": "'$zzz'"}'
-    bin/client.sh 8001 ranger.Node.Take '{"range": {"key": 1}}'
+    bin/client.sh 8001 ranger.Node.Deactivate '{"range": {"key": 1}}'
 
     # ---- test
 
@@ -198,14 +198,14 @@ teardown() {
     bin/client.sh 8001 ranger.Node.Prepare '{"range": '"$r1"'}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a1'", "value": "'$zzz'"}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a2'", "value": "'$yyy'"}'
-    bin/client.sh 8001 ranger.Node.Take '{"range": {"key": 1}}'
+    bin/client.sh 8001 ranger.Node.Deactivate '{"range": {"key": 1}}'
 
     # Node 2: range [b,c)
     r2='{"ident": {"key": 2}, "start": "'$b'", "end": "'$c'"}'
     bin/client.sh 8002 ranger.Node.Prepare '{"range": '"$r2"'}'
     bin/client.sh 8002 kv.KV.Put '{"key": "'$b1'", "value": "'$xxx'"}'
     bin/client.sh 8002 kv.KV.Put '{"key": "'$b2'", "value": "'$www'"}'
-    bin/client.sh 8002 ranger.Node.Take '{"range": {"key": 2}}'
+    bin/client.sh 8002 ranger.Node.Deactivate '{"range": {"key": 2}}'
 
     # ---- test
 
@@ -252,7 +252,7 @@ teardown() {
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a2'", "value": "'$yyy'"}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$b1'", "value": "'$xxx'"}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$b2'", "value": "'$www'"}'
-    bin/client.sh 8001 ranger.Node.Take '{"range": {"key": 1}}'
+    bin/client.sh 8001 ranger.Node.Deactivate '{"range": {"key": 1}}'
 
     # ---- test
 

--- a/examples/kv/test/node.bats
+++ b/examples/kv/test/node.bats
@@ -40,7 +40,7 @@ teardown() {
     start_node 8001
 
     # Assign the range [a,b) to node 1.
-    run bin/client.sh 8001 ranger.Node.Give '{"range": {"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}}'
+    run bin/client.sh 8001 ranger.Node.Prepare '{"range": {"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}}'
     assert_success
 
     # Try to read again. Different error.
@@ -74,7 +74,7 @@ teardown() {
     assert_line -n 2 '  Message: range not found'
 
     # Assign the range [a,b) to node 1.
-    run bin/client.sh 8001 ranger.Node.Give '{"range": {"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}}'
+    run bin/client.sh 8001 ranger.Node.Prepare '{"range": {"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}}'
     assert_success
 
     # Try to dump the contents of range 1 from node 1.
@@ -102,9 +102,9 @@ teardown() {
 
     # ---- setup
 
-    # Give the range [a,b) to node 1, Put some keys, and Take it.
+    # Prepare the range [a,b) on node 1, Put some keys, and Take it.
     r1='{"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}'
-    bin/client.sh 8001 ranger.Node.Give '{"range": '"$r1"'}'
+    bin/client.sh 8001 ranger.Node.Prepare '{"range": '"$r1"'}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a'", "value": "'$zzz'"}'
     bin/client.sh 8001 ranger.Node.Take '{"range": {"key": 1}}'
 
@@ -114,7 +114,7 @@ teardown() {
     # TODO: This succeeds even if node 1 refuses to dump it, because the
     #       transfer starts asynchronously after this rpc has returned. That
     #       doesn't seem ideal.
-    run bin/client.sh 8002 ranger.Node.Give '{"range": {"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}]}'
+    run bin/client.sh 8002 ranger.Node.Prepare '{"range": {"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}]}'
     assert_success
 
     # Read the key from node 1. This still works!
@@ -195,14 +195,14 @@ teardown() {
 
     # Node 1: range [a,b)
     r1='{"ident": {"key": 1}, "start": "'$a'", "end": "'$b'"}'
-    bin/client.sh 8001 ranger.Node.Give '{"range": '"$r1"'}'
+    bin/client.sh 8001 ranger.Node.Prepare '{"range": '"$r1"'}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a1'", "value": "'$zzz'"}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a2'", "value": "'$yyy'"}'
     bin/client.sh 8001 ranger.Node.Take '{"range": {"key": 1}}'
 
     # Node 2: range [b,c)
     r2='{"ident": {"key": 2}, "start": "'$b'", "end": "'$c'"}'
-    bin/client.sh 8002 ranger.Node.Give '{"range": '"$r2"'}'
+    bin/client.sh 8002 ranger.Node.Prepare '{"range": '"$r2"'}'
     bin/client.sh 8002 kv.KV.Put '{"key": "'$b1'", "value": "'$xxx'"}'
     bin/client.sh 8002 kv.KV.Put '{"key": "'$b2'", "value": "'$www'"}'
     bin/client.sh 8002 ranger.Node.Take '{"range": {"key": 2}}'
@@ -214,10 +214,10 @@ teardown() {
     #       weird when serving reads during the transition.
 
     # Move both ranges to a single new range on node 3
-    run bin/client.sh 8003 ranger.Node.Give '{"range": {"ident": {"key": 3}, "start": "'$a'", "end": "'$c'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}, {"range": '"$r2"', "node": "localhost:8002"}]}'
+    run bin/client.sh 8003 ranger.Node.Prepare '{"range": {"ident": {"key": 3}, "start": "'$a'", "end": "'$c'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}, {"range": '"$r2"', "node": "localhost:8002"}]}'
     assert_success
 
-    # TODO: Can be arbitrary delay here because Give returns before range
+    # TODO: Can be arbitrary delay here because Prepare returns before range
     #       recovery is finished (or even started). Need some rpc to wait for
     #       the recovery to succeed or fail. Probably just for testing.
     sleep 0.5
@@ -247,7 +247,7 @@ teardown() {
     # Assign a range and write some keys.                                                                                                                                                                                                                                                                             
     # Node 1: range [a,c)
     r1='{"ident": {"key": 1}, "start": "'$a'", "end": "'$c'"}'
-    bin/client.sh 8001 ranger.Node.Give '{"range": '"$r1"'}'
+    bin/client.sh 8001 ranger.Node.Prepare '{"range": '"$r1"'}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a1'", "value": "'$zzz'"}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$a2'", "value": "'$yyy'"}'
     bin/client.sh 8001 kv.KV.Put '{"key": "'$b1'", "value": "'$xxx'"}'
@@ -257,14 +257,14 @@ teardown() {
     # ---- test
 
     # Move half of the range to n2
-    run bin/client.sh 8002 ranger.Node.Give '{"range": {"ident": {"key": 2}, "start": "'$a'", "end": "'$b'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}]}'
+    run bin/client.sh 8002 ranger.Node.Prepare '{"range": {"ident": {"key": 2}, "start": "'$a'", "end": "'$b'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}]}'
     assert_success
 
     # Move the other half to n3
-    run bin/client.sh 8003 ranger.Node.Give '{"range": {"ident": {"key": 3}, "start": "'$b'", "end": "'$c'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}]}'
+    run bin/client.sh 8003 ranger.Node.Prepare '{"range": {"ident": {"key": 3}, "start": "'$b'", "end": "'$c'"}, "parents": [{"range": '"$r1"', "node": "localhost:8001"}]}'
     assert_success
 
-    # TODO: Can be arbitrary delay here because Give returns before range
+    # TODO: Can be arbitrary delay here because Prepare returns before range
     #       recovery is finished (or even started). Need some rpc to wait for
     #       the recovery to succeed or fail. Probably just for testing.
     sleep 0.5

--- a/examples/kv/test/node.bats
+++ b/examples/kv/test/node.bats
@@ -162,7 +162,7 @@ teardown() {
     # This would have worked at any time after node 2 finished fetching the
     # range from node 1, but one mustn't enable writes until the old node has
     # stopped serving reads, to avoid stale reads.
-    run bin/client.sh 8002 ranger.Node.Serve '{"range": {"key": 1}}'
+    run bin/client.sh 8002 ranger.Node.Activate '{"range": {"key": 1}}'
     assert_success
     assert_line -n 0 '{'
     assert_line -n 1 '  '

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -76,10 +76,10 @@ func (a *Actuator) Wait() {
 }
 
 var maxFailures = map[api.Action]int{
-	api.Give:  3,
-	api.Take:  3,
-	api.Serve: 3,
-	api.Drop:  30, // Not quite forever
+	api.Prepare: 3,
+	api.Take:    3,
+	api.Serve:   3,
+	api.Drop:    30, // Not quite forever
 }
 
 func (a *Actuator) consider(p *ranje.Placement) {
@@ -177,7 +177,7 @@ type transitions struct {
 // TODO: Move this out to some outer actuator.
 // Somewhat duplicated from placement_state.go.
 var actuations = []transitions{
-	{api.PsPending, api.PsInactive, api.Give},
+	{api.PsPending, api.PsInactive, api.Prepare},
 	{api.PsInactive, api.PsActive, api.Serve},
 	{api.PsActive, api.PsInactive, api.Take},
 	{api.PsInactive, api.PsDropped, api.Drop},
@@ -220,7 +220,7 @@ func (a *Actuator) incrementError(cmd api.Command, p *ranje.Placement, n *roster
 
 		// TODO: Can this go somewhere else? The roster needs to know that the
 		//       failure happened so it can avoid placing ranges on the node.
-		if cmd.Action == api.Give || cmd.Action == api.Serve {
+		if cmd.Action == api.Prepare || cmd.Action == api.Serve {
 			n.PlacementFailed(p.Range().Meta.Ident, time.Now())
 		}
 	}

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -76,10 +76,10 @@ func (a *Actuator) Wait() {
 }
 
 var maxFailures = map[api.Action]int{
-	api.Prepare: 3,
-	api.Take:    3,
-	api.Serve:   3,
-	api.Drop:    30, // Not quite forever
+	api.Prepare:    3,
+	api.Deactivate: 3,
+	api.Serve:      3,
+	api.Drop:       30, // Not quite forever
 }
 
 func (a *Actuator) consider(p *ranje.Placement) {
@@ -179,7 +179,7 @@ type transitions struct {
 var actuations = []transitions{
 	{api.PsPending, api.PsInactive, api.Prepare},
 	{api.PsInactive, api.PsActive, api.Serve},
-	{api.PsActive, api.PsInactive, api.Take},
+	{api.PsActive, api.PsInactive, api.Deactivate},
 	{api.PsInactive, api.PsDropped, api.Drop},
 }
 

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -78,7 +78,7 @@ func (a *Actuator) Wait() {
 var maxFailures = map[api.Action]int{
 	api.Prepare:    3,
 	api.Deactivate: 3,
-	api.Serve:      3,
+	api.Activate:   3,
 	api.Drop:       30, // Not quite forever
 }
 
@@ -178,7 +178,7 @@ type transitions struct {
 // Somewhat duplicated from placement_state.go.
 var actuations = []transitions{
 	{api.PsPending, api.PsInactive, api.Prepare},
-	{api.PsInactive, api.PsActive, api.Serve},
+	{api.PsInactive, api.PsActive, api.Activate},
 	{api.PsActive, api.PsInactive, api.Deactivate},
 	{api.PsInactive, api.PsDropped, api.Drop},
 }
@@ -220,7 +220,7 @@ func (a *Actuator) incrementError(cmd api.Command, p *ranje.Placement, n *roster
 
 		// TODO: Can this go somewhere else? The roster needs to know that the
 		//       failure happened so it can avoid placing ranges on the node.
-		if cmd.Action == api.Prepare || cmd.Action == api.Serve {
+		if cmd.Action == api.Prepare || cmd.Action == api.Activate {
 			n.PlacementFailed(p.Range().Meta.Ident, time.Now())
 		}
 	}

--- a/pkg/actuator/mock/mock_actuator.go
+++ b/pkg/actuator/mock/mock_actuator.go
@@ -49,9 +49,9 @@ func (a *Actuator) Command(cmd api.Command, p *ranje.Placement, n *roster.Node) 
 		return err
 	}
 
-	// TODO: This special case is weird. It was less so when Give was a
+	// TODO: This special case is weird. It was less so when Prepare was a
 	//       separate method. Think about it or something.
-	if cmd.Action == api.Give {
+	if cmd.Action == api.Prepare {
 		n.UpdateRangeInfo(&api.RangeInfo{
 			Meta:  p.Range().Meta,
 			State: s,
@@ -107,10 +107,10 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 // fake remote transition at all, because real nodes (with rangelets) can assume
 // whatever state they like.
 var defaults = map[api.Action]api.RemoteState{
-	api.Give:  api.NsInactive,
-	api.Serve: api.NsActive,
-	api.Take:  api.NsInactive,
-	api.Drop:  api.NsNotFound,
+	api.Prepare: api.NsInactive,
+	api.Serve:   api.NsActive,
+	api.Take:    api.NsInactive,
+	api.Drop:    api.NsNotFound,
 }
 
 func mustDefault(action api.Action) api.RemoteState {

--- a/pkg/actuator/mock/mock_actuator.go
+++ b/pkg/actuator/mock/mock_actuator.go
@@ -107,10 +107,10 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 // fake remote transition at all, because real nodes (with rangelets) can assume
 // whatever state they like.
 var defaults = map[api.Action]api.RemoteState{
-	api.Prepare: api.NsInactive,
-	api.Serve:   api.NsActive,
-	api.Take:    api.NsInactive,
-	api.Drop:    api.NsNotFound,
+	api.Prepare:    api.NsInactive,
+	api.Serve:      api.NsActive,
+	api.Deactivate: api.NsInactive,
+	api.Drop:       api.NsNotFound,
 }
 
 func mustDefault(action api.Action) api.RemoteState {

--- a/pkg/actuator/mock/mock_actuator.go
+++ b/pkg/actuator/mock/mock_actuator.go
@@ -108,7 +108,7 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 // whatever state they like.
 var defaults = map[api.Action]api.RemoteState{
 	api.Prepare:    api.NsInactive,
-	api.Serve:      api.NsActive,
+	api.Activate:   api.NsActive,
 	api.Deactivate: api.NsInactive,
 	api.Drop:       api.NsNotFound,
 }

--- a/pkg/actuator/rpc/actuator.go
+++ b/pkg/actuator/rpc/actuator.go
@@ -65,7 +65,7 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 	case api.Serve:
 		s, err = serve(ctx, n, p)
 
-	case api.Take:
+	case api.Deactivate:
 		s, err = take(ctx, n, p)
 
 	case api.Drop:
@@ -115,12 +115,12 @@ func serve(ctx context.Context, n *roster.Node, p *ranje.Placement) (pb.RangeNod
 
 func take(ctx context.Context, n *roster.Node, p *ranje.Placement) (pb.RangeNodeState, error) {
 	rID := p.Range().Meta.Ident
-	req := &pb.TakeRequest{
+	req := &pb.DeactivateRequest{
 		Range: conv.RangeIDToProto(rID),
 	}
 
 	// TODO: Retry a few times before giving up.
-	res, err := n.Client.Take(ctx, req)
+	res, err := n.Client.Deactivate(ctx, req)
 	if err != nil {
 		return pb.RangeNodeState_UNKNOWN, err
 	}

--- a/pkg/actuator/rpc/actuator.go
+++ b/pkg/actuator/rpc/actuator.go
@@ -36,9 +36,9 @@ func (a *Actuator) Command(cmd api.Command, p *ranje.Placement, n *roster.Node) 
 		return err
 	}
 
-	// TODO: This special case is weird. It was less so when Give was a
+	// TODO: This special case is weird. It was less so when Prepare was a
 	//       separate method. Think about it or something.
-	if cmd.Action == api.Give {
+	if cmd.Action == api.Prepare {
 		n.UpdateRangeInfo(&api.RangeInfo{
 			Meta:  p.Range().Meta,
 			State: s,
@@ -59,7 +59,7 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 	var err error
 
 	switch action {
-	case api.Give:
+	case api.Prepare:
 		s, err = give(ctx, n, p, util.GetParents(a.rg, a.ng, p.Range()))
 
 	case api.Serve:
@@ -84,13 +84,13 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 }
 
 func give(ctx context.Context, n *roster.Node, p *ranje.Placement, parents []*pb.Parent) (pb.RangeNodeState, error) {
-	req := &pb.GiveRequest{
+	req := &pb.PrepareRequest{
 		Range:   conv.MetaToProto(p.Range().Meta),
 		Parents: parents,
 	}
 
 	// TODO: Retry a few times before giving up.
-	res, err := n.Client.Give(ctx, req)
+	res, err := n.Client.Prepare(ctx, req)
 	if err != nil {
 		return pb.RangeNodeState_UNKNOWN, err
 	}

--- a/pkg/actuator/rpc/actuator.go
+++ b/pkg/actuator/rpc/actuator.go
@@ -62,7 +62,7 @@ func (a *Actuator) cmd(action api.Action, p *ranje.Placement, n *roster.Node) (a
 	case api.Prepare:
 		s, err = give(ctx, n, p, util.GetParents(a.rg, a.ng, p.Range()))
 
-	case api.Serve:
+	case api.Activate:
 		s, err = serve(ctx, n, p)
 
 	case api.Deactivate:
@@ -105,7 +105,7 @@ func serve(ctx context.Context, n *roster.Node, p *ranje.Placement) (pb.RangeNod
 	}
 
 	// TODO: Retry a few times before giving up.
-	res, err := n.Client.Serve(ctx, req)
+	res, err := n.Client.Activate(ctx, req)
 	if err != nil {
 		return pb.RangeNodeState_UNKNOWN, err
 	}

--- a/pkg/actuator/rpc/actuator_test.go
+++ b/pkg/actuator/rpc/actuator_test.go
@@ -22,7 +22,7 @@ import (
 	"gotest.tools/assert/cmp"
 )
 
-func TestGive(t *testing.T) {
+func TestPrepare(t *testing.T) {
 	h := setup(t)
 	p := getPlacement(t, h.rangeGetter, 2, 0)
 	n, err := h.nodeGetter.NodeByIdent("node-aaa")
@@ -31,7 +31,7 @@ func TestGive(t *testing.T) {
 	cmd := api.Command{
 		RangeIdent: 2,
 		NodeIdent:  "node-aaa",
-		Action:     api.Give,
+		Action:     api.Prepare,
 	}
 
 	// success
@@ -39,8 +39,8 @@ func TestGive(t *testing.T) {
 	err = h.actuator.Command(cmd, p, n)
 	assert.NilError(t, err)
 
-	assert.Assert(t, h.node.giveReq != nil)
-	assert.DeepEqual(t, pb.GiveRequest{
+	assert.Assert(t, h.node.prepareReq != nil)
+	assert.DeepEqual(t, pb.PrepareRequest{
 		Range: &pb.RangeMeta{
 			Ident: 2,
 			End:   []byte("ccc"),
@@ -72,11 +72,11 @@ func TestGive(t *testing.T) {
 				},
 			},
 		},
-	}, h.node.giveReq, protocmp.Transform())
+	}, h.node.prepareReq, protocmp.Transform())
 
 	// error
 
-	h.node.giveErr = status.Errorf(codes.InvalidArgument, "injected")
+	h.node.prepareErr = status.Errorf(codes.InvalidArgument, "injected")
 
 	err = h.actuator.Command(cmd, p, n)
 	assert.Error(t, err, "rpc error: code = InvalidArgument desc = injected")
@@ -243,8 +243,8 @@ func (rg *FakeNodeGetter) NodeByIdent(nID api.NodeID) (*roster.Node, error) {
 type NodeServer struct {
 	pb.UnsafeNodeServer
 
-	giveErr error
-	giveReq *pb.GiveRequest
+	prepareErr error
+	prepareReq *pb.PrepareRequest
 
 	serveReq *pb.ServeRequest
 	serveErr error
@@ -256,14 +256,14 @@ type NodeServer struct {
 	dropErr error
 }
 
-func (ns *NodeServer) Give(ctx context.Context, req *pb.GiveRequest) (*pb.GiveResponse, error) {
-	ns.giveReq = req
+func (ns *NodeServer) Prepare(ctx context.Context, req *pb.PrepareRequest) (*pb.PrepareResponse, error) {
+	ns.prepareReq = req
 
-	if ns.giveErr != nil {
-		return nil, ns.giveErr
+	if ns.prepareErr != nil {
+		return nil, ns.prepareErr
 	}
 
-	return &pb.GiveResponse{
+	return &pb.PrepareResponse{
 		RangeInfo: &pb.RangeInfo{
 			Meta: &pb.RangeMeta{
 				Ident: 0,

--- a/pkg/actuator/rpc/actuator_test.go
+++ b/pkg/actuator/rpc/actuator_test.go
@@ -91,7 +91,7 @@ func TestServe(t *testing.T) {
 	cmd := api.Command{
 		RangeIdent: 3,
 		NodeIdent:  "node-aaa",
-		Action:     api.Serve,
+		Action:     api.Activate,
 	}
 
 	// success
@@ -279,7 +279,7 @@ func (ns *NodeServer) Prepare(ctx context.Context, req *pb.PrepareRequest) (*pb.
 	}, nil
 }
 
-func (ns *NodeServer) Serve(ctx context.Context, req *pb.ServeRequest) (*pb.ServeResponse, error) {
+func (ns *NodeServer) Activate(ctx context.Context, req *pb.ServeRequest) (*pb.ServeResponse, error) {
 	ns.serveReq = req
 
 	if ns.serveErr != nil {

--- a/pkg/actuator/rpc/actuator_test.go
+++ b/pkg/actuator/rpc/actuator_test.go
@@ -113,7 +113,7 @@ func TestServe(t *testing.T) {
 	assert.Error(t, err, "rpc error: code = FailedPrecondition desc = injected")
 }
 
-func TestTake(t *testing.T) {
+func TestDeactivate(t *testing.T) {
 	h := setup(t)
 	p := getPlacement(t, h.rangeGetter, 3, 0)
 	n, err := h.nodeGetter.NodeByIdent("node-aaa")
@@ -122,7 +122,7 @@ func TestTake(t *testing.T) {
 	cmd := api.Command{
 		RangeIdent: 3,
 		NodeIdent:  "node-aaa",
-		Action:     api.Take,
+		Action:     api.Deactivate,
 	}
 
 	// success
@@ -131,7 +131,7 @@ func TestTake(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Assert(t, h.node.takeReq != nil)
-	assert.DeepEqual(t, pb.TakeRequest{
+	assert.DeepEqual(t, pb.DeactivateRequest{
 		Range: 3,
 	}, h.node.takeReq, protocmp.Transform())
 
@@ -249,7 +249,7 @@ type NodeServer struct {
 	serveReq *pb.ServeRequest
 	serveErr error
 
-	takeReq *pb.TakeRequest
+	takeReq *pb.DeactivateRequest
 	takeErr error
 
 	dropReq *pb.DropRequest
@@ -291,14 +291,14 @@ func (ns *NodeServer) Serve(ctx context.Context, req *pb.ServeRequest) (*pb.Serv
 	}, nil
 }
 
-func (ns *NodeServer) Take(ctx context.Context, req *pb.TakeRequest) (*pb.TakeResponse, error) {
+func (ns *NodeServer) Deactivate(ctx context.Context, req *pb.DeactivateRequest) (*pb.DeactivateResponse, error) {
 	ns.takeReq = req
 
 	if ns.takeErr != nil {
 		return nil, ns.takeErr
 	}
 
-	return &pb.TakeResponse{
+	return &pb.DeactivateResponse{
 		State: pb.RangeNodeState_INACTIVE,
 	}, nil
 }

--- a/pkg/api/action.go
+++ b/pkg/api/action.go
@@ -9,7 +9,7 @@ const (
 	NoAction Action = iota
 	Prepare
 	Serve
-	Take
+	Deactivate
 	Drop
 )
 

--- a/pkg/api/action.go
+++ b/pkg/api/action.go
@@ -8,7 +8,7 @@ type Action uint8
 const (
 	NoAction Action = iota
 	Prepare
-	Serve
+	Activate
 	Deactivate
 	Drop
 )

--- a/pkg/api/action.go
+++ b/pkg/api/action.go
@@ -7,7 +7,7 @@ type Action uint8
 
 const (
 	NoAction Action = iota
-	Give
+	Prepare
 	Serve
 	Take
 	Drop

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -20,8 +20,8 @@ type Node interface {
 	// AddRange
 	AddRange(rID RangeID) error
 
-	// PrepareDropRange
-	PrepareDropRange(rID RangeID) error
+	// Deactivate
+	Deactivate(rID RangeID) error
 
 	// DropRange
 	// Range state will be set to NsDropping before calling this. If an error is

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -11,7 +11,7 @@ type Node interface {
 	// GetLoadInfo returns the LoadInfo for the given range.
 	// Implementations should return NotFound if (from their point of view) the
 	// range doesn't exist. This can happen when GetLoadInfo and Prepare and/or
-	// DropRange are racing.
+	// Drop are racing.
 	GetLoadInfo(rID RangeID) (LoadInfo, error)
 
 	// Prepare.
@@ -23,9 +23,9 @@ type Node interface {
 	// Deactivate
 	Deactivate(rID RangeID) error
 
-	// DropRange
+	// Drop
 	// Range state will be set to NsDropping before calling this. If an error is
 	// returned, the range will be forgotten. If no error is returned, the range
 	// state will be set to NsDroppingError.
-	DropRange(rID RangeID) error
+	Drop(rID RangeID) error
 }

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -6,9 +6,6 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
-// These don't match the Prepare/Give/Take/Drop terminology used internally by
-// Ranger, but Shard Manager uses roughly (s/Shard/Range/g) these terms. Better
-// to follow those than invent our own.
 type Node interface {
 
 	// GetLoadInfo returns the LoadInfo for the given range.

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -17,8 +17,8 @@ type Node interface {
 	// Prepare.
 	Prepare(m Meta, p []Parent) error
 
-	// AddRange
-	AddRange(rID RangeID) error
+	// Activate
+	Activate(rID RangeID) error
 
 	// Deactivate
 	Deactivate(rID RangeID) error

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -13,12 +13,12 @@ type Node interface {
 
 	// GetLoadInfo returns the LoadInfo for the given range.
 	// Implementations should return NotFound if (from their point of view) the
-	// range doesn't exist. This can happen when GetLoadInfo and PrepareAddRange
-	// and/or DropRange are racing.
+	// range doesn't exist. This can happen when GetLoadInfo and Prepare and/or
+	// DropRange are racing.
 	GetLoadInfo(rID RangeID) (LoadInfo, error)
 
-	// PrepareAddRange.
-	PrepareAddRange(m Meta, p []Parent) error
+	// Prepare.
+	Prepare(m Meta, p []Parent) error
 
 	// AddRange
 	AddRange(rID RangeID) error

--- a/pkg/api/placement_state.go
+++ b/pkg/api/placement_state.go
@@ -9,7 +9,7 @@ const (
 	PsPending
 	PsInactive
 	PsActive
-	PsGiveUp
+	PsMissing
 	PsDropped
 )
 

--- a/pkg/api/remote_state.go
+++ b/pkg/api/remote_state.go
@@ -12,10 +12,10 @@ const (
 	NsActive
 
 	// During transitions
-	NsLoading      // Pending  -> PreReady
-	NsActivating   // PreReady -> Ready
-	NsDeactivating // Ready    -> PreReady
-	NsDropping     // PreReady -> NotFound
+	NsPreparing    // Pending  -> Inactive
+	NsActivating   // Inactive -> Active
+	NsDeactivating // Active   -> Inactive
+	NsDropping     // Inactive -> NotFound
 
 	// Special case: This is never returned by probes, since those only include
 	// the state of ranges which the node has. This is returned by redundant

--- a/pkg/api/zzz_action_string.go
+++ b/pkg/api/zzz_action_string.go
@@ -9,15 +9,15 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[NoAction-0]
-	_ = x[Give-1]
+	_ = x[Prepare-1]
 	_ = x[Serve-2]
 	_ = x[Take-3]
 	_ = x[Drop-4]
 }
 
-const _Action_name = "NoActionGiveServeTakeDrop"
+const _Action_name = "NoActionPrepareServeTakeDrop"
 
-var _Action_index = [...]uint8{0, 8, 12, 17, 21, 25}
+var _Action_index = [...]uint8{0, 8, 15, 20, 24, 28}
 
 func (i Action) String() string {
 	if i >= Action(len(_Action_index)-1) {

--- a/pkg/api/zzz_action_string.go
+++ b/pkg/api/zzz_action_string.go
@@ -10,14 +10,14 @@ func _() {
 	var x [1]struct{}
 	_ = x[NoAction-0]
 	_ = x[Prepare-1]
-	_ = x[Serve-2]
+	_ = x[Activate-2]
 	_ = x[Deactivate-3]
 	_ = x[Drop-4]
 }
 
-const _Action_name = "NoActionPrepareServeDeactivateDrop"
+const _Action_name = "NoActionPrepareActivateDeactivateDrop"
 
-var _Action_index = [...]uint8{0, 8, 15, 20, 30, 34}
+var _Action_index = [...]uint8{0, 8, 15, 23, 33, 37}
 
 func (i Action) String() string {
 	if i >= Action(len(_Action_index)-1) {

--- a/pkg/api/zzz_action_string.go
+++ b/pkg/api/zzz_action_string.go
@@ -11,13 +11,13 @@ func _() {
 	_ = x[NoAction-0]
 	_ = x[Prepare-1]
 	_ = x[Serve-2]
-	_ = x[Take-3]
+	_ = x[Deactivate-3]
 	_ = x[Drop-4]
 }
 
-const _Action_name = "NoActionPrepareServeTakeDrop"
+const _Action_name = "NoActionPrepareServeDeactivateDrop"
 
-var _Action_index = [...]uint8{0, 8, 15, 20, 24, 28}
+var _Action_index = [...]uint8{0, 8, 15, 20, 30, 34}
 
 func (i Action) String() string {
 	if i >= Action(len(_Action_index)-1) {

--- a/pkg/api/zzz_placement_state.go
+++ b/pkg/api/zzz_placement_state.go
@@ -16,9 +16,9 @@ func _() {
 	_ = x[PsDropped-5]
 }
 
-const _PlacementState_name = "PsUnknownPsPendingPsInactivePsActivePsGiveUpPsDropped"
+const _PlacementState_name = "PsUnknownPsPendingPsInactivePsActivePsMissingPsDropped"
 
-var _PlacementState_index = [...]uint8{0, 9, 18, 28, 36, 44, 53}
+var _PlacementState_index = [...]uint8{0, 9, 18, 28, 36, 45, 54}
 
 func (i PlacementState) String() string {
 	if i >= PlacementState(len(_PlacementState_index)-1) {

--- a/pkg/api/zzz_placement_state.go
+++ b/pkg/api/zzz_placement_state.go
@@ -12,7 +12,7 @@ func _() {
 	_ = x[PsPending-1]
 	_ = x[PsInactive-2]
 	_ = x[PsActive-3]
-	_ = x[PsGiveUp-4]
+	_ = x[PsMissing-4]
 	_ = x[PsDropped-5]
 }
 

--- a/pkg/api/zzz_remote_state.go
+++ b/pkg/api/zzz_remote_state.go
@@ -11,16 +11,16 @@ func _() {
 	_ = x[NsUnknown-0]
 	_ = x[NsInactive-1]
 	_ = x[NsActive-2]
-	_ = x[NsLoading-3]
+	_ = x[NsPreparing-3]
 	_ = x[NsActivating-4]
 	_ = x[NsDeactivating-5]
 	_ = x[NsDropping-6]
 	_ = x[NsNotFound-7]
 }
 
-const _RemoteState_name = "NsUnknownNsInactiveNsActiveNsLoadingNsActivatingNsDeactivatingNsDroppingNsNotFound"
+const _RemoteState_name = "NsUnknownNsInactiveNsActiveNsPreparingNsActivatingNsDeactivatingNsDroppingNsNotFound"
 
-var _RemoteState_index = [...]uint8{0, 9, 19, 27, 36, 48, 62, 72, 82}
+var _RemoteState_index = [...]uint8{0, 9, 19, 27, 38, 50, 64, 74, 84}
 
 func (i RemoteState) String() string {
 	if i >= RemoteState(len(_RemoteState_index)-1) {

--- a/pkg/discovery/consul/consul_discoverer.go
+++ b/pkg/discovery/consul/consul_discoverer.go
@@ -13,7 +13,7 @@ type Discoverer struct {
 	consul *consulapi.Client
 }
 
-// TODO: Take a consul API client here, not a cfg.
+// TODO: Deactivate a consul API client here, not a cfg.
 func NewDiscoverer(cfg *consulapi.Config) (*Discoverer, error) {
 	client, err := consulapi.NewClient(cfg)
 	if err != nil {

--- a/pkg/discovery/consul/consul_discovery.go
+++ b/pkg/discovery/consul/consul_discovery.go
@@ -28,7 +28,7 @@ func (d *Discovery) getIdent() string {
 	return fmt.Sprintf("%s:%d", d.host, d.port)
 }
 
-// TODO: Take a consul API here, not a cfg.
+// TODO: Deactivate a consul API here, not a cfg.
 func New(serviceName, addr string, cfg *consulapi.Config, srv *grpc.Server) (*Discovery, error) {
 	client, err := consulapi.NewClient(cfg)
 	if err != nil {

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -354,7 +354,7 @@ func (ks *Keyspace) mustPersistDirtyRanges() error {
 func (ks *Keyspace) JoinTwo(one *ranje.Range, two *ranje.Range) (*ranje.Range, error) {
 	for _, r := range []*ranje.Range{one, two} {
 		if r.State != api.RsActive {
-			return nil, errors.New("can't join non-ready ranges")
+			return nil, errors.New("can't join non-active ranges")
 		}
 
 		// This should not be possible. Panic?

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -451,7 +451,7 @@ func TestPlacementMayBeDeactivated(t *testing.T) {
 		output [][]string
 	}{
 		{
-			name: "ready with no replacement",
+			name: "active with no replacement",
 			input: []*ranje.Range{
 				{
 					State:      api.RsActive,

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -444,7 +444,7 @@ func TestPlacementMayBecomeReady(t *testing.T) {
 	}
 }
 
-func TestPlacementMayBeTaken(t *testing.T) {
+func TestPlacementMayBeDeactivated(t *testing.T) {
 	examples := []struct {
 		name   string
 		input  []*ranje.Range

--- a/pkg/keyspace/operations.go
+++ b/pkg/keyspace/operations.go
@@ -198,7 +198,7 @@ func isRecalling(parents, children []*ranje.Range) bool {
 	//       maybe untangle this.
 	for _, rc := range parents {
 		for _, pc := range rc.Placements {
-			if pc.Failed(api.Take) {
+			if pc.Failed(api.Deactivate) {
 				out = true
 			}
 		}
@@ -392,7 +392,7 @@ func (op *Operation) MayDeactivate(p *ranje.Placement, r *ranje.Range) error {
 		return fmt.Errorf("placment not in api.PsActive")
 	}
 
-	if p.Failed(api.Take) {
+	if p.Failed(api.Deactivate) {
 		return fmt.Errorf("gave up")
 	}
 
@@ -401,10 +401,10 @@ func (op *Operation) MayDeactivate(p *ranje.Placement, r *ranje.Range) error {
 		// If this placement is being replaced by another...
 		if other := replacementFor(p); other != nil {
 
-			// There is another placement replacing this one, but we've given up on
-			// it, so will destroy that (the replacement) rather than taking this
-			// one. We might have already taken this one once, and then reverted it
-			// back because the replacement failed to become ready.
+			// There is another placement replacing this one, but we've given up
+			// on it, so will destroy the replacement rather than deactivating
+			// this one. We might have already deactivated this one once, and
+			// then reverted it back because the replacement failed to activate.
 			if other.Failed(api.Serve) {
 				return fmt.Errorf("replacement has given up")
 			}
@@ -510,7 +510,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 
 			// If the other placement has failed to deactivate, might as well
 			// drop this one (the replacements) while an operator intervenes.
-			if other.Failed(api.Take) {
+			if other.Failed(api.Deactivate) {
 				return nil
 			}
 		}

--- a/pkg/keyspace/operations.go
+++ b/pkg/keyspace/operations.go
@@ -351,9 +351,9 @@ func (op *Operation) MayActivate(p *ranje.Placement, r *ranje.Range) error {
 	if op == nil {
 
 		// If one of the sibling placements (on the same range) claims to be
-		// replacing this range, then it mustn't become ready (unless that sibling
-		// has given up). It was probably just moved from ready to Idle so that the
-		// sibling could become ready.
+		// replacing this range, then it mustn't activate (unless that sibling
+		// has given up). It was probably just deactivated so that the sibling
+		// could activate.
 		if other := replacementFor(p); other != nil {
 			if !other.Failed(api.Activate) {
 				return fmt.Errorf("will be replaced by sibling")
@@ -446,7 +446,7 @@ func (op *Operation) MayDeactivate(p *ranje.Placement, r *ranje.Range) error {
 			}
 
 			// TODO: This is weird. Why are we waiting for the *maximum* number
-			//       of placements to be ready in the dest? I think it's because
+			//       of active placements in the dest? I think it's because
 			//       min/max doesn't make much sense until we have replicas.
 			if n < rc.MaxActive() {
 				return fmt.Errorf("not enough inactive children")
@@ -539,7 +539,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 
 		// Can't drop until all of the destination ranges have enough active
 		// placements. They might still need the contents of this parent range
-		// to make themselves ready.
+		// to activate.
 		for _, r2 := range op.direction(Dest) {
 
 			active := 0

--- a/pkg/keyspace/operations.go
+++ b/pkg/keyspace/operations.go
@@ -215,10 +215,9 @@ func isRecalling(parents, children []*ranje.Range) bool {
 		}
 	}
 
-	// What of FailedGive (or FailedPrepareAddRange, or FailedLoad or whatever
-	// I'm calling it today), and of FailedDrop?
+	// What of FailedPrepare and of FailedDrop?
 	//
-	// Firstly, there is no FailedGive; the placement is just destroyed if it
+	// Firstly, there is no FailedPrepare; the placement is just destroyed if it
 	// isn't accepted by the node. Secondly, even if there were, we don't have
 	// to roll anything back to handle it. Placement happens before the parent
 	// ranges are deactivated, so can be re-tried as many times as necessary

--- a/pkg/keyspace/operations.go
+++ b/pkg/keyspace/operations.go
@@ -194,8 +194,8 @@ func isRecalling(parents, children []*ranje.Range) bool {
 	// gaps while we wait for an operator (or node crash).
 	//
 	// TODO: Is this necessary if there's only one parent? What can even be done
-	//       except the split becoming wedged? TestSplitFailure_PrepareDropRange
-	//       will maybe untangle this.
+	//       except the split becoming wedged? TestSplitFailure_Deactivate will
+	//       maybe untangle this.
 	for _, rc := range parents {
 		for _, pc := range rc.Placements {
 			if pc.Failed(api.Take) {

--- a/pkg/keyspace/operations.go
+++ b/pkg/keyspace/operations.go
@@ -209,7 +209,7 @@ func isRecalling(parents, children []*ranje.Range) bool {
 	// ensure no gaps while we give the failed range(s) to some other node.
 	for _, rc := range children {
 		for _, pc := range rc.Placements {
-			if pc.Failed(api.Serve) {
+			if pc.Failed(api.Activate) {
 				out = true
 			}
 		}
@@ -329,8 +329,8 @@ func (op *Operation) MayActivate(p *ranje.Placement, r *ranje.Range) error {
 	}
 
 	// If this placement has been given up on, it's destined to be dropped
-	// rather than served. We might have tried to serve it and failed.
-	if p.Failed(api.Serve) {
+	// rather than activated. We might have tried to activate it and failed.
+	if p.Failed(api.Activate) {
 		return fmt.Errorf("gave up")
 	}
 
@@ -355,7 +355,7 @@ func (op *Operation) MayActivate(p *ranje.Placement, r *ranje.Range) error {
 		// has given up). It was probably just moved from ready to Idle so that the
 		// sibling could become ready.
 		if other := replacementFor(p); other != nil {
-			if !other.Failed(api.Serve) {
+			if !other.Failed(api.Activate) {
 				return fmt.Errorf("will be replaced by sibling")
 			}
 		}
@@ -405,7 +405,7 @@ func (op *Operation) MayDeactivate(p *ranje.Placement, r *ranje.Range) error {
 			// on it, so will destroy the replacement rather than deactivating
 			// this one. We might have already deactivated this one once, and
 			// then reverted it back because the replacement failed to activate.
-			if other.Failed(api.Serve) {
+			if other.Failed(api.Activate) {
 				return fmt.Errorf("replacement has given up")
 			}
 
@@ -500,7 +500,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 			// other placement should be reactivated and this one should be
 			// dropped. In order to make that a bit safer and more orderly,
 			// delay the drop until after the other one has reactivated.
-			if p.Failed(api.Serve) {
+			if p.Failed(api.Activate) {
 				if other.StateCurrent == api.PsActive {
 					return nil
 				} else {
@@ -520,7 +520,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 		// is about to be activated, so don't drop it unless that's already been
 		// tried and failed.
 
-		if p.Failed(api.Serve) {
+		if p.Failed(api.Activate) {
 			return nil
 		}
 
@@ -528,7 +528,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 	}
 
 	if op.isDirection(Dest, r.Meta.Ident) {
-		if p.Failed(api.Serve) {
+		if p.Failed(api.Activate) {
 			return nil
 		}
 
@@ -547,7 +547,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 				if p2.StateCurrent == api.PsActive {
 					active += 1
 				}
-				if p2.Failed(api.Serve) {
+				if p2.Failed(api.Activate) {
 					return fmt.Errorf("child range has placement given up, which will be dropped")
 				}
 			}
@@ -566,7 +566,7 @@ func (op *Operation) MayDrop(p *ranje.Placement, r *ranje.Range) error {
 		// back, so do drop it.
 
 		if op.isChild(r.Meta.Ident) {
-			if p.Failed(api.Serve) {
+			if p.Failed(api.Activate) {
 				return nil
 			}
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -485,7 +485,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 		ri, ok := n.Get(p.Range().Meta.Ident)
 		if ok {
 			switch ri.State {
-			case api.NsLoading:
+			case api.NsPreparing:
 				p.Want(api.PsInactive)
 
 			case api.NsInactive:

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -425,11 +425,11 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 	destroy = false
 
 	// Get the node that this placement is on. If the node couldn't be fetched,
-	// it's probably crashed, so move the placement to GiveUp so it's replaced.
+	// it's probably crashed, so move the placement to Missing so it's replaced.
 	n, err := b.rost.NodeByIdent(p.NodeID)
 	if err != nil {
-		if p.StateCurrent != api.PsGiveUp && p.StateCurrent != api.PsDropped {
-			b.ks.PlacementToState(p, api.PsGiveUp)
+		if p.StateCurrent != api.PsMissing && p.StateCurrent != api.PsDropped {
+			b.ks.PlacementToState(p, api.PsMissing)
 			return
 		}
 	}
@@ -498,7 +498,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 
 			default:
 				log.Printf("unexpected remote state: ris=%s, psc=%s", ri.State, p.StateCurrent)
-				b.ks.PlacementToState(p, api.PsGiveUp)
+				b.ks.PlacementToState(p, api.PsMissing)
 			}
 		} else {
 			doPlace = true
@@ -529,7 +529,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 			}
 
 			// Otherwise, abort. It's been forgotten.
-			b.ks.PlacementToState(p, api.PsGiveUp)
+			b.ks.PlacementToState(p, api.PsMissing)
 			return
 		}
 
@@ -568,7 +568,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 
 		default:
 			log.Printf("unexpected remote state: ris=%s, psc=%s", ri.State, p.StateCurrent)
-			b.ks.PlacementToState(p, api.PsGiveUp)
+			b.ks.PlacementToState(p, api.PsMissing)
 			return
 		}
 
@@ -578,7 +578,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 		ri, ok := n.Get(p.Range().Meta.Ident)
 		if !ok {
 			// The node doesn't have the placement any more! Abort.
-			b.ks.PlacementToState(p, api.PsGiveUp)
+			b.ks.PlacementToState(p, api.PsMissing)
 			return
 		}
 
@@ -594,7 +594,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 
 		default:
 			log.Printf("unexpected remote state: ris=%s, psc=%s", ri.State, p.StateCurrent)
-			b.ks.PlacementToState(p, api.PsGiveUp)
+			b.ks.PlacementToState(p, api.PsMissing)
 		}
 
 		if doDeactivate {
@@ -603,7 +603,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 			}
 		}
 
-	case api.PsGiveUp:
+	case api.PsMissing:
 		// This transition only exists to provide an error-handling path to
 		// PsDropped without sending any RPCs.
 		b.ks.PlacementToState(p, api.PsDropped)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -120,12 +120,12 @@ func (b *Orchestrator) Tick() {
 			r3.Placements = append(r3.Placements, p)
 
 			// Unlock operator RPC if applicable.
-			// Note that this will only fire if *this* placement becomes ready.
-			// If it fails, and is replaced, and that succeeds, the RPC will
-			// never unblock.
+			// Note that this will only fire if *this* placement activates. If
+			// it fails, and is replaced, and that succeeds, the RPC will never
+			// unblock.
 			//
 			// TODO: Move this to range.OnReady, which should only fire when
-			//       the minReady number of placements are ready.
+			//       the minReady number of placements are active.
 			//
 			if opJoin.Err != nil {
 				p.OnReady(func() {
@@ -388,7 +388,7 @@ func (b *Orchestrator) doMove(r *ranje.Range, opMove OpMove) error {
 		}
 
 		if src == nil {
-			return fmt.Errorf("no ready placement found (rID=%v)", r.Meta.Ident)
+			return fmt.Errorf("no active placement found (rID=%v)", r.Meta.Ident)
 		}
 	}
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -480,7 +480,8 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 		// If the node already has the range (i.e. this is not the first tick
 		// where the placement is PsPending, so the RPC may already have been
 		// sent), check its remote state, which may have been updated by a
-		// response to a Give or by a periodic probe. We may be able to advance.
+		// response to a Prepare or by a periodic probe. We may be able to
+		// advance.
 		ri, ok := n.Get(p.Range().Meta.Ident)
 		if ok {
 			switch ri.State {
@@ -491,8 +492,8 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 				b.ks.PlacementToState(p, api.PsInactive)
 
 			case api.NsNotFound:
-				// Special case: Give has already been attempted, but it failed.
-				// We can try again, same as if the placement was missing.
+				// Special case: Prepare has already been attempted, but it
+				// failed. We can try again, as if the placement was missing.
 				doPlace = true
 
 			default:
@@ -505,7 +506,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 
 		if doPlace {
 			p.Want(api.PsInactive)
-			if p.Failed(api.Give) {
+			if p.Failed(api.Prepare) {
 				destroy = true
 			}
 		}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -573,7 +573,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 		}
 
 	case api.PsActive:
-		doTake := false
+		doDeactivate := false
 
 		ri, ok := n.Get(p.Range().Meta.Ident)
 		if !ok {
@@ -584,7 +584,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 
 		switch ri.State {
 		case api.NsActive:
-			doTake = true
+			doDeactivate = true
 
 		case api.NsDeactivating:
 			p.Want(api.PsInactive)
@@ -597,7 +597,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 			b.ks.PlacementToState(p, api.PsGiveUp)
 		}
 
-		if doTake {
+		if doDeactivate {
 			if err := op.MayDeactivate(p, r); err == nil {
 				p.Want(api.PsInactive)
 			}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -517,7 +517,7 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 
 			// The node doesn't have the placement any more! Maybe we tried to
 			// activate it but gave up.
-			if p.Failed(api.Serve) {
+			if p.Failed(api.Activate) {
 				destroy = true
 				return
 			}
@@ -553,10 +553,10 @@ func (b *Orchestrator) tickPlacement(p *ranje.Placement, r *ranje.Range, op *key
 			return
 
 		case api.NsActivating:
-			// We've already sent the Serve RPC at least once, and the node is
-			// working on it. Just keep waiting. But send another Serve RPC to
-			// check whether it's finished and is now Ready. (Or has changed to
-			// some other state through crash or bug.)
+			// We've already sent the Activate RPC at least once, and the node
+			// is working on it. Just keep waiting. But send another Activate
+			// RPC to check whether it's finished and is now Ready. (Or has
+			// changed to some other state through crash or bug.)
 			p.Want(api.PsActive)
 
 		case api.NsDropping:

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -229,7 +229,7 @@ func TestPlaceFailure_AddRange(t *testing.T) {
 	p := mustGetPlacement(t, orch.ks, 1, "test-aaa")
 	require.True(t, p.Failed(api.Serve))
 
-	// 3. DropRange(1, aaa)
+	// 3. Drop(1, aaa)
 
 	tickWait(t, orch, act)
 	require.Equal(t, "Drop(R1, test-aaa)", commands(t, act))
@@ -527,8 +527,8 @@ func TestMoveFailure_Deactivate(t *testing.T) {
 	p := mustGetPlacement(t, orch.ks, 1, "test-aaa")
 	require.True(t, p.Failed(api.Deactivate))
 
-	// 3. Node B gets DropRange, to abandon the placement it prepared. It will
-	//    never become ready.
+	// 3. Node B gets Drop, to abandon the placement it prepared. It will never
+	//    become ready.
 
 	tickWait(t, orch, act)
 	assert.Equal(t, "Drop(R1, test-bbb)", commands(t, act))
@@ -610,7 +610,7 @@ func TestMoveFailure_AddRange(t *testing.T) {
 	// require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive p1=test-bbb:PsInactive:replacing(test-aaa)}", orch.ks.LogString())
 	// require.Equal(t, "{test-aaa [1:NsActive]} {test-bbb [1:NsInactive]}", orch.rost.TestString())
 
-	// 5. DropRange(1, bbb)
+	// 5. Drop(1, bbb)
 	tickWait(t, orch, act)
 	require.Equal(t, "Drop(R1, test-bbb)", commands(t, act))
 	require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive p1=test-bbb:PsInactive:replacing(test-aaa)}", orch.ks.LogString())
@@ -624,7 +624,7 @@ func TestMoveFailure_AddRange(t *testing.T) {
 	requireStable(t, orch, act)
 }
 
-func TestMoveFailure_DropRange(t *testing.T) {
+func TestMoveFailure_Drop(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -632,7 +632,7 @@ func TestMoveFailure_DropRange(t *testing.T) {
 
 	i1d := inject(t, act, "test-aaa", 1, api.Drop).Failure()
 
-	// Fast-forward to the part where we send DropRange to aaa.
+	// Fast-forward to the part where we send Drop to aaa.
 	tickUntil(t, orch, act, func(ks, ro string) bool {
 		return (true &&
 			ks == "{1 [-inf, +inf] RsActive p0=test-aaa:PsInactive p1=test-bbb:PsActive:replacing(test-aaa)}" &&
@@ -707,7 +707,7 @@ func TestSplit(t *testing.T) {
 	assert.Equal(t, "{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsInactive} {2 [-inf, ccc] RsActive p0=test-aaa:PsActive} {3 (ccc, +inf] RsActive p0=test-aaa:PsActive}", orch.ks.LogString())
 	assert.Equal(t, "{test-aaa [1:NsInactive 2:NsActive 3:NsActive]}", orch.rost.TestString())
 
-	// 4. DropRange
+	// 4. Drop
 
 	tickWait(t, orch, act)
 	require.Equal(t, "Drop(R1, test-aaa)", commands(t, act))
@@ -1089,7 +1089,7 @@ func TestSplitFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{test-aaa [1:NsActive]} {test-bbb [2:NsInactive 3:NsInactive]} {test-ccc []}", orch.rost.TestString())
 	require.Equal(t, "{Split 1 <- 2,3}", OpsString(orch.ks))
 
-	// 6. DropRange
+	// 6. Drop
 	// The failed child is dropped.
 
 	tickWait(t, orch, act)
@@ -1120,11 +1120,11 @@ func TestSplitFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{test-aaa []} {test-bbb [3:NsActive]} {test-ccc [2:NsActive]}", orch.rost.TestString())
 }
 
-func TestSplitFailure_DropRange(t *testing.T) {
+func TestSplitFailure_Drop(t *testing.T) {
 	t.Skip("not implemented")
 }
 
-func TestSplitFailure_DropRange_Short(t *testing.T) {
+func TestSplitFailure_Drop_Short(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []} {test-ccc []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -1503,7 +1503,7 @@ func TestJoinFailure_AddRange_Short(t *testing.T) {
 
 }
 
-func TestJoinFailure_DropRange_Short(t *testing.T) {
+func TestJoinFailure_Drop_Short(t *testing.T) {
 	ksStr := "{1 [-inf, ggg] RsActive p0=test-aaa:PsActive} {2 (ggg, +inf] RsActive p0=test-bbb:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb [2:NsActive]} {test-ccc []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -74,15 +74,15 @@ func TestPlace(t *testing.T) {
 	require.Equal(t, "{test-aaa [1:NsInactive]}", orch.rost.TestString())
 	require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsInactive}", orch.ks.LogString())
 
-	// Third: Activate RPC is sent, to advance to ready. Returns success, and
-	// roster is updated. Keyspace is not.
+	// Third: Activate RPC is sent. Returns success, and roster is updated.
+	// Keyspace is not.
 
 	tickWait(t, orch, act)
 	require.Equal(t, "Activate(R1, test-aaa)", commands(t, act))
 	require.Equal(t, "{test-aaa [1:NsActive]}", orch.rost.TestString())
 	require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsInactive}", orch.ks.LogString())
 
-	// Forth: Keyspace is updated with ready state from roster. No RPCs sent.
+	// Forth: Keyspace is updated with active state from roster. No RPCs sent.
 
 	tickWait(t, orch, act)
 	require.Empty(t, commands(t, act))
@@ -528,7 +528,7 @@ func TestMoveFailure_Deactivate(t *testing.T) {
 	require.True(t, p.Failed(api.Deactivate))
 
 	// 3. Node B gets Drop, to abandon the placement it prepared. It will never
-	//    become ready.
+	//    activate.
 
 	tickWait(t, orch, act)
 	assert.Equal(t, "Drop(R1, test-bbb)", commands(t, act))
@@ -1240,7 +1240,7 @@ func TestJoin_Slow(t *testing.T) {
 	require.Equal(t, "{1 [-inf, ggg] RsSubsuming p0=test-aaa:PsInactive} {2 (ggg, +inf] RsSubsuming p0=test-bbb:PsInactive} {3 [-inf, +inf] RsActive p0=test-ccc:PsInactive}", orch.ks.LogString())
 	require.Equal(t, "{test-aaa [1:NsInactive]} {test-bbb [2:NsInactive]} {test-ccc [3:NsActivating]}", orch.rost.TestString())
 
-	// New range becomes ready.
+	// New range activates.
 	requireStable(t, orch, act)
 	i3s.Response(api.NsActive)
 

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -492,7 +492,7 @@ func TestMoveFailure_Prepare(t *testing.T) {
 	requireStable(t, orch, act)
 }
 
-func TestMoveFailure_PrepareDropRange(t *testing.T) {
+func TestMoveFailure_Deactivate(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -513,7 +513,7 @@ func TestMoveFailure_PrepareDropRange(t *testing.T) {
 	assert.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive p1=test-bbb:PsInactive:replacing(test-aaa)}", orch.ks.LogString())
 	assert.Equal(t, "{test-aaa [1:NsActive]} {test-bbb [1:NsInactive]}", orch.rost.TestString())
 
-	// 2. Node A gets PrepareDropRange, which fails because we injected an error
+	// 2. Node A gets Deactivate, which fails because we injected an error
 	//    above. This repeats three times before we give up and accept that the
 	//    node will not relinquish the range.
 
@@ -688,7 +688,7 @@ func TestSplit(t *testing.T) {
 	assert.Equal(t, "{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsActive} {2 [-inf, ccc] RsActive p0=test-aaa:PsInactive} {3 (ccc, +inf] RsActive p0=test-aaa:PsInactive}", orch.ks.LogString())
 	assert.Equal(t, "{test-aaa [1:NsActive 2:NsInactive 3:NsInactive]}", orch.rost.TestString())
 
-	// 2. PrepareDropRange
+	// 2. Deactivate
 
 	tickWait(t, orch, act)
 	assert.Equal(t, "Take(R1, test-aaa)", commands(t, act))
@@ -972,7 +972,7 @@ func TestSplitFailure_Prepare(t *testing.T) {
 	assert.Equal(t, "{test-aaa []} {test-bbb [3:NsActive]} {test-ccc [2:NsActive]}", orch.rost.TestString())
 }
 
-func TestSplitFailure_PrepareDropRange_Short(t *testing.T) {
+func TestSplitFailure_Deactivate_Short(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []} {test-ccc []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -991,7 +991,7 @@ func TestSplitFailure_PrepareDropRange_Short(t *testing.T) {
 	assert.True(t, p.Failed(api.Take))
 }
 
-func TestSplitFailure_PrepareDropRange(t *testing.T) {
+func TestSplitFailure_Deactivate(t *testing.T) {
 	t.Skip("not implemented")
 }
 
@@ -1031,7 +1031,7 @@ func TestSplitFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsActive} {2 [-inf, ccc] RsActive p0=test-bbb:PsInactive} {3 (ccc, +inf] RsActive p0=test-bbb:PsInactive}", orch.ks.LogString())
 	require.Equal(t, "{test-aaa [1:NsActive]} {test-bbb [2:NsInactive 3:NsInactive]} {test-ccc []}", orch.rost.TestString())
 
-	// 2. PrepareDropRange
+	// 2. Deactivate
 
 	tickWait(t, orch, act)
 	require.Equal(t, "Take(R1, test-aaa)", commands(t, act))
@@ -1059,7 +1059,7 @@ func TestSplitFailure_AddRange(t *testing.T) {
 	p := mustGetPlacement(t, orch.ks, 2, "test-bbb")
 	require.True(t, p.Failed(api.Serve))
 
-	// 4. PrepareDropRange
+	// 4. Deactivate
 	//
 	// Undo the Serve that succeeded, so we can reactivate the predecessor while
 	// a new placement is found for the Serve that failed. Prepare can be slow,
@@ -1336,7 +1336,7 @@ func TestJoinFailure_Prepare(t *testing.T) {
 	require.Equal(t, "{test-aaa []} {test-bbb []} {test-ccc []} {test-ddd [3:NsActive]}", orch.rost.TestString())
 }
 
-func TestJoinFailure_PrepareDropRange(t *testing.T) {
+func TestJoinFailure_Deactivate(t *testing.T) {
 	ksStr := "{1 [-inf, ggg] RsActive p0=test-aaa:PsActive} {2 (ggg, +inf] RsActive p0=test-bbb:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb [2:NsActive]} {test-ccc []} {test-ddd []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -1429,7 +1429,7 @@ func TestJoinFailure_Deactivate(t *testing.T) {
 
 	tickWait(t, orch, act)
 	require.Equal(t, "Activate(R3, test-ccc)", commands(t, act))
-	require.Equal(t, "{1 [-inf, ggg] RsSubsuming p0=test-aaa:PsGiveUp} {2 (ggg, +inf] RsSubsuming p0=test-bbb:PsInactive} {3 [-inf, +inf] RsActive p0=test-ccc:PsInactive}", orch.ks.LogString())
+	require.Equal(t, "{1 [-inf, ggg] RsSubsuming p0=test-aaa:PsMissing} {2 (ggg, +inf] RsSubsuming p0=test-bbb:PsInactive} {3 [-inf, +inf] RsActive p0=test-ccc:PsInactive}", orch.ks.LogString())
 	require.Equal(t, "{test-aaa []} {test-bbb [2:NsInactive]} {test-ccc [3:NsActive]} {test-ddd []}", orch.rost.TestString())
 
 	tickWait(t, orch, act)
@@ -1531,7 +1531,7 @@ func TestMissingPlacement(t *testing.T) {
 
 	tickWait(t, orch, act)
 	assert.Empty(t, commands(t, act))
-	assert.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsGiveUp}", orch.ks.LogString())
+	assert.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsMissing}", orch.ks.LogString())
 	assert.Equal(t, "{test-aaa []}", orch.rost.TestString())
 
 	// Orchestrator advances to drop the placement, but (unlike when moving)
@@ -1793,8 +1793,8 @@ func placementStateFromString(t *testing.T, s string) api.PlacementState {
 	case api.PsActive.String():
 		return api.PsActive
 
-	case api.PsGiveUp.String():
-		return api.PsGiveUp
+	case api.PsMissing.String():
+		return api.PsMissing
 
 	case api.PsDropped.String():
 		return api.PsDropped

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -181,7 +181,7 @@ func TestPlaceFailure_Prepare_Short(t *testing.T) {
 }
 
 // TODO: Maybe remove this test since we have the long version below?
-func TestPlaceFailure_AddRange_Short(t *testing.T) {
+func TestPlaceFailure_Activate_Short(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive}"
 	rosStr := "{test-aaa []} {test-bbb []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -195,7 +195,7 @@ func TestPlaceFailure_AddRange_Short(t *testing.T) {
 	assert.Equal(t, "{test-aaa []} {test-bbb [1:NsActive]}", orch.rost.TestString())
 }
 
-func TestPlaceFailure_AddRange(t *testing.T) {
+func TestPlaceFailure_Activate(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive}"
 	rosStr := "{test-aaa []} {test-bbb []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -216,7 +216,7 @@ func TestPlaceFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsInactive}", orch.ks.LogString())
 	require.Equal(t, "{test-aaa [1:NsInactive]} {test-bbb []}", orch.rost.TestString())
 
-	// 2. AddRange(1, aaa)
+	// 2. Activate(1, aaa)
 	//    Makes three attempts.
 
 	for attempt := 1; attempt <= 3; attempt++ {
@@ -242,7 +242,7 @@ func TestPlaceFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{test-aaa []} {test-bbb []}", orch.rost.TestString())
 
 	// 4. Prepare(1, bbb)
-	// 5. AddRange(1, bbb)
+	// 5. Activate(1, bbb)
 
 	tickUntilStable(t, orch, act)
 	require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-bbb:PsActive}", orch.ks.LogString())
@@ -552,7 +552,7 @@ func TestMoveFailure_Deactivate(t *testing.T) {
 	requireStable(t, orch, act)
 }
 
-func TestMoveFailure_AddRange(t *testing.T) {
+func TestMoveFailure_Activate(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -584,7 +584,7 @@ func TestMoveFailure_AddRange(t *testing.T) {
 	// require.Equal(t, "{1 [-inf, +inf] RsActive p0=test-aaa:PsInactive p1=test-bbb:PsInactive:replacing(test-aaa)}", orch.ks.LogString())
 	// require.Equal(t, "{test-aaa [1:NsInactive]} {test-bbb [1:NsInactive]}", orch.rost.TestString())
 
-	// 3. AddRange(1, bbb)
+	// 3. Activate(1, bbb)
 	//    Makes three attempts, which will all fail because we stubbed them to
 	//    to do so, above.
 	for attempt := 1; attempt <= 3; attempt++ {
@@ -695,7 +695,7 @@ func TestSplit(t *testing.T) {
 	assert.Equal(t, "{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsActive} {2 [-inf, ccc] RsActive p0=test-aaa:PsInactive} {3 (ccc, +inf] RsActive p0=test-aaa:PsInactive}", orch.ks.LogString())
 	assert.Equal(t, "{test-aaa [1:NsInactive 2:NsInactive 3:NsInactive]}", orch.rost.TestString())
 
-	// 3. AddRange
+	// 3. Activate
 
 	tickWait(t, orch, act)
 	assert.Equal(t, "Serve(R2, test-aaa), Serve(R3, test-aaa)", commands(t, act))
@@ -995,7 +995,7 @@ func TestSplitFailure_Deactivate(t *testing.T) {
 	t.Skip("not implemented")
 }
 
-func TestSplitFailure_AddRange_Short(t *testing.T) {
+func TestSplitFailure_Activate_Short(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []} {test-ccc []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -1007,7 +1007,7 @@ func TestSplitFailure_AddRange_Short(t *testing.T) {
 	assert.Equal(t, "{test-aaa []} {test-bbb [3:NsActive]} {test-ccc [2:NsActive]}", orch.rost.TestString())
 }
 
-func TestSplitFailure_AddRange(t *testing.T) {
+func TestSplitFailure_Activate(t *testing.T) {
 	ksStr := "{1 [-inf, +inf] RsActive p0=test-aaa:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb []} {test-ccc []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)
@@ -1038,7 +1038,7 @@ func TestSplitFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{1 [-inf, +inf] RsSubsuming p0=test-aaa:PsActive} {2 [-inf, ccc] RsActive p0=test-bbb:PsInactive} {3 (ccc, +inf] RsActive p0=test-bbb:PsInactive}", orch.ks.LogString())
 	require.Equal(t, "{test-aaa [1:NsInactive]} {test-bbb [2:NsInactive 3:NsInactive]} {test-ccc []}", orch.rost.TestString())
 
-	// 3. AddRange
+	// 3. Activate
 	// Three attempts. The first one goes to both sides of the split, succeeds
 	// on the right side (R3), but fails on the left (R2). The next two attempts
 	// only go to the failed side, and it fails twice more.
@@ -1078,7 +1078,7 @@ func TestSplitFailure_AddRange(t *testing.T) {
 	require.Equal(t, "{test-aaa [1:NsInactive]} {test-bbb [2:NsInactive 3:NsInactive]} {test-ccc []}", orch.rost.TestString())
 	require.Equal(t, "{Split 1 <- 2,3}", OpsString(orch.ks))
 
-	// 5. AddRange
+	// 5. Activate
 	//
 	// The parent (R1) is now reactivated, so it can be active while the failed
 	// child is replaced.
@@ -1469,7 +1469,7 @@ func TestJoinFailure_Deactivate(t *testing.T) {
 	requireStable(t, orch, act)
 }
 
-func TestJoinFailure_AddRange_Short(t *testing.T) {
+func TestJoinFailure_Activate_Short(t *testing.T) {
 	ksStr := "{1 [-inf, ggg] RsActive p0=test-aaa:PsActive} {2 (ggg, +inf] RsActive p0=test-bbb:PsActive}"
 	rosStr := "{test-aaa [1:NsActive]} {test-bbb [2:NsActive]} {test-ccc []}"
 	orch, act := orchFactory(t, ksStr, rosStr, noStrictTransactions)

--- a/pkg/proto/conv/placement_state.go
+++ b/pkg/proto/conv/placement_state.go
@@ -18,8 +18,8 @@ func PlacementStateFromProto(ps pb.PlacementState) api.PlacementState {
 		return api.PsInactive
 	case pb.PlacementState_PS_ACTIVE:
 		return api.PsActive
-	case pb.PlacementState_PS_GIVE_UP:
-		return api.PsGiveUp
+	case pb.PlacementState_PS_MISSING:
+		return api.PsMissing
 	case pb.PlacementState_PS_DROPPED:
 		return api.PsDropped
 	}
@@ -38,8 +38,8 @@ func PlacementStateToProto(ps api.PlacementState) pb.PlacementState {
 		return pb.PlacementState_PS_INACTIVE
 	case api.PsActive:
 		return pb.PlacementState_PS_ACTIVE
-	case api.PsGiveUp:
-		return pb.PlacementState_PS_GIVE_UP
+	case api.PsMissing:
+		return pb.PlacementState_PS_MISSING
 	case api.PsDropped:
 		return pb.PlacementState_PS_DROPPED
 	}

--- a/pkg/proto/conv/remote_state.go
+++ b/pkg/proto/conv/remote_state.go
@@ -16,8 +16,8 @@ func RemoteStateFromProto(s pb.RangeNodeState) api.RemoteState {
 		return api.NsInactive
 	case pb.RangeNodeState_ACTIVE:
 		return api.NsActive
-	case pb.RangeNodeState_LOADING:
-		return api.NsLoading
+	case pb.RangeNodeState_PREPARING:
+		return api.NsPreparing
 	case pb.RangeNodeState_ACTIVATING:
 		return api.NsActivating
 	case pb.RangeNodeState_DEACTIVATING:
@@ -40,8 +40,8 @@ func RemoteStateToProto(rs api.RemoteState) pb.RangeNodeState {
 		return pb.RangeNodeState_INACTIVE
 	case api.NsActive:
 		return pb.RangeNodeState_ACTIVE
-	case api.NsLoading:
-		return pb.RangeNodeState_LOADING
+	case api.NsPreparing:
+		return pb.RangeNodeState_PREPARING
 	case api.NsActivating:
 		return pb.RangeNodeState_ACTIVATING
 	case api.NsDeactivating:

--- a/pkg/proto/node.proto
+++ b/pkg/proto/node.proto
@@ -8,7 +8,7 @@ package ranger;
 
 service Node {
   rpc Prepare (PrepareRequest) returns (PrepareResponse) {}
-  rpc Serve (ServeRequest) returns (ServeResponse) {}
+  rpc Activate (ServeRequest) returns (ServeResponse) {}
   rpc Deactivate (DeactivateRequest) returns (DeactivateResponse) {}
   rpc Drop (DropRequest) returns (DropResponse) {}
 

--- a/pkg/proto/node.proto
+++ b/pkg/proto/node.proto
@@ -9,7 +9,7 @@ package ranger;
 service Node {
   rpc Prepare (PrepareRequest) returns (PrepareResponse) {}
   rpc Serve (ServeRequest) returns (ServeResponse) {}
-  rpc Take (TakeRequest) returns (TakeResponse) {}
+  rpc Deactivate (DeactivateRequest) returns (DeactivateResponse) {}
   rpc Drop (DropRequest) returns (DropResponse) {}
 
   // Controller wants to know the state of the node, including its ranges.
@@ -56,11 +56,11 @@ message ServeResponse {
   RangeNodeState state = 1;
 }
 
-message TakeRequest {
+message DeactivateRequest {
   uint64 range = 1;
 }
 
-message TakeResponse {
+message DeactivateResponse {
   RangeNodeState state = 1;
 }
 

--- a/pkg/proto/node.proto
+++ b/pkg/proto/node.proto
@@ -7,7 +7,7 @@ import "ranje.proto";
 package ranger;
 
 service Node {
-  rpc Give (GiveRequest) returns (GiveResponse) {}
+  rpc Prepare (PrepareRequest) returns (PrepareResponse) {}
   rpc Serve (ServeRequest) returns (ServeResponse) {}
   rpc Take (TakeRequest) returns (TakeResponse) {}
   rpc Drop (DropRequest) returns (DropResponse) {}
@@ -24,7 +24,7 @@ service Node {
 message Parent {
   RangeMeta range = 1;
 
-  // Range IDs in here may not appear in the GiveRequest, because at some point
+  // Range IDs in here may not appear in the PrepareRequest, because at some point
   // the history is pruned.
   repeated uint64 parent = 2;
 
@@ -32,7 +32,7 @@ message Parent {
   repeated Placement placements = 3;
 }
 
-message GiveRequest {
+message PrepareRequest {
   RangeMeta range = 1;
 
   // The range(s) which this range was created from, and the nodes where they
@@ -42,7 +42,7 @@ message GiveRequest {
   repeated Parent parents = 3;
 }
 
-message GiveResponse {
+message PrepareResponse {
   // TODO: Return just the state instead, like ServeResponse.
   RangeInfo range_info = 1;
 }

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -89,6 +89,6 @@ enum PlacementState {
   PS_PENDING = 1;
   PS_INACTIVE = 2;
   PS_ACTIVE = 3;
-  PS_GIVE_UP = 5;
+  PS_MISSING = 5;
   PS_DROPPED = 6;
 }

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -13,7 +13,7 @@ message RangeMeta {
   bytes end = 3; // exclusive
 }
 
-// Sent from the controller when PrepareAddRange.
+// Sent from the controller with Prepare.
 // TODO: Should include the placement index in here, so the node can verify that
 //       the controller is talking about the same placement when it sees
 //       duplicates. Just in case the controller has gone mad and is trying to

--- a/pkg/proto/ranje.proto
+++ b/pkg/proto/ranje.proto
@@ -63,10 +63,10 @@ enum RangeNodeState {
   ACTIVE = 2;
 
   // During transitions
-  LOADING = 3;      // Pending -> PreReady
-  ACTIVATING = 4;   // PreReady -> Ready
-  DEACTIVATING = 5; // Ready -> PreReady
-  DROPPING = 6;     // PreReady -> NotFound
+  PREPARING = 3;    // Pending -> Inactive
+  ACTIVATING = 4;   // Inactive -> Active
+  DEACTIVATING = 5; // Active -> Inactive
+  DROPPING = 6;     // Inactive -> NotFound
 
   // Special case: See roster.RemoteState
   NOT_FOUND = 7;

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -176,7 +176,7 @@ func (r *Rangelet) serve(rID api.RangeID) (api.RangeInfo, error) {
 	ri, ok := r.info[rID]
 	if !ok {
 		r.Unlock()
-		return api.RangeInfo{}, status.Errorf(codes.InvalidArgument, "can't Serve unknown range: %v", rID)
+		return api.RangeInfo{}, status.Errorf(codes.InvalidArgument, "can't Activate unknown range: %v", rID)
 	}
 
 	if ri.State == api.NsActivating || ri.State == api.NsActive {
@@ -186,7 +186,7 @@ func (r *Rangelet) serve(rID api.RangeID) (api.RangeInfo, error) {
 
 	if ri.State != api.NsInactive {
 		r.Unlock()
-		return *ri, status.Errorf(codes.InvalidArgument, "invalid state for Serve: %v", ri.State)
+		return *ri, status.Errorf(codes.InvalidArgument, "invalid state for Activate: %v", ri.State)
 	}
 
 	// State is NsInactive

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -115,7 +115,7 @@ func (r *Rangelet) runThenUpdateState(rID api.RangeID, old api.RemoteState, succ
 	r.notifyWatchers(ri)
 }
 
-func (r *Rangelet) give(rm api.Meta, parents []api.Parent) (api.RangeInfo, error) {
+func (r *Rangelet) prepare(rm api.Meta, parents []api.Parent) (api.RangeInfo, error) {
 	rID := rm.Ident
 	r.Lock()
 
@@ -127,7 +127,7 @@ func (r *Rangelet) give(rm api.Meta, parents []api.Parent) (api.RangeInfo, error
 			return *ri, nil
 		}
 
-		return *ri, status.Errorf(codes.InvalidArgument, "invalid state for Give: %v", ri.State)
+		return *ri, status.Errorf(codes.InvalidArgument, "invalid state for Prepare: %v", ri.State)
 	}
 
 	// Range is not currently known, so can be added.

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -104,7 +104,7 @@ func (r *Rangelet) runThenUpdateState(rID api.RangeID, old api.RemoteState, succ
 	ri.State = s
 
 	// Special case: Ranges are never actually in NotFound; it's a signal to
-	// delete them. This happens when a Prepare fails, or a DropRange succeeds;
+	// delete them. This happens when a Prepare fails, or a Drop succeeds;
 	// either way, the range is gone.
 	if ri.State == api.NsNotFound {
 		delete(r.info, rID)
@@ -288,7 +288,7 @@ func (r *Rangelet) drop(rID api.RangeID) (api.RangeInfo, error) {
 
 	withTimeout(r.gracePeriod, func() {
 		r.runThenUpdateState(rID, api.NsDropping, api.NsNotFound, api.NsInactive, func() error {
-			return r.n.DropRange(rID)
+			return r.n.Drop(rID)
 		})
 	})
 
@@ -302,7 +302,7 @@ func (r *Rangelet) drop(rID api.RangeID) (api.RangeInfo, error) {
 	}
 
 	// The range is still here.
-	// DropRange is presumably still running.
+	// Drop is presumably still running.
 	return *ri, nil
 }
 
@@ -314,9 +314,9 @@ func (r *Rangelet) Find(k api.Key) (api.RangeID, bool) {
 
 		// Play dumb in some cases: a range can be known to the rangelet but
 		// unknown to the client, in these states. (Find might have been called
-		// before Prepare has returned, or while DropRange is still in
-		// progress.) The client should check the state anyway, but this makes
-		// the contract simpler.
+		// before Prepare has returned, or while Drop is still in progress.) The
+		// client should check the state anyway, but this makes the contract
+		// simpler.
 		if ri.State == api.NsPreparing || ri.State == api.NsDropping {
 			continue
 		}

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -242,7 +242,7 @@ func (r *Rangelet) take(rID api.RangeID) (api.RangeInfo, error) {
 
 	withTimeout(r.gracePeriod, func() {
 		r.runThenUpdateState(rID, api.NsDeactivating, api.NsInactive, api.NsActive, func() error {
-			return r.n.PrepareDropRange(rID)
+			return r.n.Deactivate(rID)
 		})
 	})
 

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -220,7 +220,7 @@ func (r *Rangelet) take(rID api.RangeID) (api.RangeInfo, error) {
 	ri, ok := r.info[rID]
 	if !ok {
 		r.Unlock()
-		return api.RangeInfo{}, status.Errorf(codes.InvalidArgument, "can't Take unknown range: %v", rID)
+		return api.RangeInfo{}, status.Errorf(codes.InvalidArgument, "can't Deactivate unknown range: %v", rID)
 	}
 
 	if ri.State == api.NsDeactivating || ri.State == api.NsInactive {
@@ -230,7 +230,7 @@ func (r *Rangelet) take(rID api.RangeID) (api.RangeInfo, error) {
 
 	if ri.State != api.NsActive {
 		r.Unlock()
-		return *ri, status.Errorf(codes.InvalidArgument, "invalid state for Take: %v", ri.State)
+		return *ri, status.Errorf(codes.InvalidArgument, "invalid state for Deactivate: %v", ri.State)
 	}
 
 	// State is NsActive

--- a/pkg/rangelet/rangelet.go
+++ b/pkg/rangelet/rangelet.go
@@ -198,7 +198,7 @@ func (r *Rangelet) serve(rID api.RangeID) (api.RangeInfo, error) {
 
 	withTimeout(r.gracePeriod, func() {
 		r.runThenUpdateState(rID, api.NsActivating, api.NsActive, api.NsInactive, func() error {
-			return r.n.AddRange(rID)
+			return r.n.Activate(rID)
 		})
 	})
 

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -273,18 +273,18 @@ func TestServeErrorSlow(t *testing.T) {
 	}, waitFor, tick)
 }
 
-func setupTake(infos map[api.RangeID]*api.RangeInfo, m api.Meta) {
+func setupDeactivate(infos map[api.RangeID]*api.RangeInfo, m api.Meta) {
 	infos[m.Ident] = &api.RangeInfo{
 		Meta:  m,
 		State: api.NsActive,
 	}
 }
 
-func TestTakeFast(t *testing.T) {
+func TestDeactivateFast(t *testing.T) {
 	_, rglt := Setup()
 
 	m := api.Meta{Ident: 1}
-	setupTake(rglt.info, m)
+	setupDeactivate(rglt.info, m)
 
 	ri, err := rglt.take(m.Ident)
 	require.NoError(t, err)
@@ -303,11 +303,11 @@ func TestTakeFast(t *testing.T) {
 	assert.Equal(t, api.NsInactive, ri.State)
 }
 
-func TestTakeSlow(t *testing.T) {
+func TestDeactivateSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := api.Meta{Ident: 1}
-	setupTake(rglt.info, m)
+	setupDeactivate(rglt.info, m)
 
 	n.wgDeactivate.Add(1)
 
@@ -342,19 +342,19 @@ func TestTakeSlow(t *testing.T) {
 	}
 }
 
-func TestTakeUnknown(t *testing.T) {
+func TestDeactivateUnknown(t *testing.T) {
 	_, rglt := Setup()
 
 	ri, err := rglt.take(1)
-	require.EqualError(t, err, "rpc error: code = InvalidArgument desc = can't Take unknown range: 1")
+	require.EqualError(t, err, "rpc error: code = InvalidArgument desc = can't Deactivate unknown range: 1")
 	assert.Equal(t, api.RangeInfo{}, ri)
 }
 
-func TestTakeErrorFast(t *testing.T) {
+func TestDeactivateErrorFast(t *testing.T) {
 	n, rglt := Setup()
 
 	m := api.Meta{Ident: 1}
-	setupTake(rglt.info, m)
+	setupDeactivate(rglt.info, m)
 
 	n.erDeactivate = errors.New("error from Deactivate")
 
@@ -369,11 +369,11 @@ func TestTakeErrorFast(t *testing.T) {
 	assert.Equal(t, api.NsActive, ri.State)
 }
 
-func TestTakeErrorSlow(t *testing.T) {
+func TestDeactivateErrorSlow(t *testing.T) {
 	n, rglt := Setup()
 
 	m := api.Meta{Ident: 1}
-	setupTake(rglt.info, m)
+	setupDeactivate(rglt.info, m)
 
 	// Deactivate will block, then return an error.
 	n.erDeactivate = errors.New("error from Deactivate")
@@ -517,7 +517,7 @@ func TestDropErrorSlow(t *testing.T) {
 	// Unblock DropRange.
 	n.wgDropRange.Done()
 
-	// Wait until state returns to Taken (because DropRange returned error).
+	// Wait until state returns to Deactivated (because DropRange returned error).
 	require.Eventually(t, func() bool {
 		ri, ok := rglt.rangeInfo(m.Ident)
 		return ok && ri.State == api.NsInactive

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -220,7 +220,7 @@ func TestServeUnknown(t *testing.T) {
 	_, rglt := Setup()
 
 	ri, err := rglt.serve(1)
-	require.EqualError(t, err, "rpc error: code = InvalidArgument desc = can't Serve unknown range: 1")
+	require.EqualError(t, err, "rpc error: code = InvalidArgument desc = can't Activate unknown range: 1")
 	assert.Equal(t, api.RangeInfo{}, ri)
 }
 

--- a/pkg/rangelet/rangelet_test.go
+++ b/pkg/rangelet/rangelet_test.go
@@ -67,7 +67,7 @@ func TestPrepareSlow(t *testing.T) {
 		ri, err := rglt.prepare(m, p)
 		require.NoError(t, err)
 		assert.Equal(t, ri.Meta, m)
-		assert.Equal(t, api.NsLoading, ri.State)
+		assert.Equal(t, api.NsPreparing, ri.State)
 	}
 
 	called := atomic.LoadUint32(&n.nPrepare)
@@ -75,7 +75,7 @@ func TestPrepareSlow(t *testing.T) {
 
 	ri, ok := rglt.rangeInfo(m.Ident)
 	require.True(t, ok)
-	assert.Equal(t, api.NsLoading, ri.State)
+	assert.Equal(t, api.NsPreparing, ri.State)
 
 	// Unblock Prepare.
 	n.wgPrepare.Done()
@@ -128,12 +128,12 @@ func TestPrepareErrorSlow(t *testing.T) {
 
 	// Prepare the range. Even though the client will eventually return error
 	// from Prepare, the outer call (give succeeds because it will exceed the
-	// grace period and respond with Loading.
+	// grace period and respond with NsPreparing.
 	for i := 0; i < 2; i++ {
 		ri, err := rglt.prepare(m, p)
 		require.NoError(t, err)
 		assert.Equal(t, m, ri.Meta)
-		assert.Equal(t, api.NsLoading, ri.State)
+		assert.Equal(t, api.NsPreparing, ri.State)
 	}
 
 	called := atomic.LoadUint32(&n.nPrepare)

--- a/pkg/rangelet/server.go
+++ b/pkg/rangelet/server.go
@@ -58,7 +58,7 @@ func parentsFromProto(prot []*pb.Parent) ([]api.Parent, error) {
 	return p, nil
 }
 
-func (ns *NodeServer) Give(ctx context.Context, req *pb.GiveRequest) (*pb.GiveResponse, error) {
+func (ns *NodeServer) Prepare(ctx context.Context, req *pb.PrepareRequest) (*pb.PrepareResponse, error) {
 	meta, err := conv.MetaFromProto(req.Range)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error parsing range meta: %v", err)
@@ -69,12 +69,12 @@ func (ns *NodeServer) Give(ctx context.Context, req *pb.GiveRequest) (*pb.GiveRe
 		return nil, status.Errorf(codes.InvalidArgument, "error parsing parents: %v", err)
 	}
 
-	ri, err := ns.r.give(meta, parents)
+	ri, err := ns.r.prepare(meta, parents)
 	if err != nil {
 		return nil, err
 	}
 
-	return &pb.GiveResponse{
+	return &pb.PrepareResponse{
 		RangeInfo: conv.RangeInfoToProto(ri),
 	}, nil
 }

--- a/pkg/rangelet/server.go
+++ b/pkg/rangelet/server.go
@@ -95,7 +95,7 @@ func (ns *NodeServer) Serve(ctx context.Context, req *pb.ServeRequest) (*pb.Serv
 	}, nil
 }
 
-func (ns *NodeServer) Take(ctx context.Context, req *pb.TakeRequest) (*pb.TakeResponse, error) {
+func (ns *NodeServer) Deactivate(ctx context.Context, req *pb.DeactivateRequest) (*pb.DeactivateResponse, error) {
 	rID, err := conv.RangeIDFromProto(req.Range)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -106,7 +106,7 @@ func (ns *NodeServer) Take(ctx context.Context, req *pb.TakeRequest) (*pb.TakeRe
 		return nil, err
 	}
 
-	return &pb.TakeResponse{
+	return &pb.DeactivateResponse{
 		State: conv.RemoteStateToProto(ri.State),
 	}, nil
 }

--- a/pkg/rangelet/server.go
+++ b/pkg/rangelet/server.go
@@ -79,7 +79,7 @@ func (ns *NodeServer) Prepare(ctx context.Context, req *pb.PrepareRequest) (*pb.
 	}, nil
 }
 
-func (ns *NodeServer) Serve(ctx context.Context, req *pb.ServeRequest) (*pb.ServeResponse, error) {
+func (ns *NodeServer) Activate(ctx context.Context, req *pb.ServeRequest) (*pb.ServeResponse, error) {
 	rID, err := conv.RangeIDFromProto(req.Range)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/pkg/ranje/placement.go
+++ b/pkg/ranje/placement.go
@@ -33,7 +33,7 @@ type Placement struct {
 
 	// Set by the orchestrator to indicate that this placement was created to
 	// replace the placement of the same range on some other node. Should be
-	// cleared once the placement becomes ready.
+	// cleared once the placement activates.
 	// TODO: Change this to some kind of uuid.
 	IsReplacing api.NodeID `json:",omitempty"`
 

--- a/pkg/ranje/placement_state_transition.go
+++ b/pkg/ranje/placement_state_transition.go
@@ -16,7 +16,7 @@ var PlacementStateTransitions []PlacementStateTransition
 func init() {
 	PlacementStateTransitions = []PlacementStateTransition{
 		// Happy Path
-		{api.PsPending, api.PsInactive}, // Give
+		{api.PsPending, api.PsInactive}, // Prepare
 		{api.PsInactive, api.PsActive},  // Serve
 		{api.PsActive, api.PsInactive},  // Take
 		{api.PsInactive, api.PsDropped}, // Drop

--- a/pkg/ranje/placement_state_transition.go
+++ b/pkg/ranje/placement_state_transition.go
@@ -22,12 +22,12 @@ func init() {
 		{api.PsInactive, api.PsDropped}, // Drop
 
 		// Node crashed (or placement mysteriously vanished)
-		{api.PsPending, api.PsGiveUp},
-		{api.PsInactive, api.PsGiveUp},
-		{api.PsActive, api.PsGiveUp},
+		{api.PsPending, api.PsMissing},
+		{api.PsInactive, api.PsMissing},
+		{api.PsActive, api.PsMissing},
 
 		// Recovery?
-		{api.PsGiveUp, api.PsDropped},
+		{api.PsMissing, api.PsDropped},
 	}
 }
 

--- a/pkg/ranje/placement_state_transition.go
+++ b/pkg/ranje/placement_state_transition.go
@@ -18,7 +18,7 @@ func init() {
 		// Happy Path
 		{api.PsPending, api.PsInactive}, // Prepare
 		{api.PsInactive, api.PsActive},  // Serve
-		{api.PsActive, api.PsInactive},  // Take
+		{api.PsActive, api.PsInactive},  // Deactivate
 		{api.PsInactive, api.PsDropped}, // Drop
 
 		// Node crashed (or placement mysteriously vanished)

--- a/pkg/ranje/placement_state_transition.go
+++ b/pkg/ranje/placement_state_transition.go
@@ -17,7 +17,7 @@ func init() {
 	PlacementStateTransitions = []PlacementStateTransition{
 		// Happy Path
 		{api.PsPending, api.PsInactive}, // Prepare
-		{api.PsInactive, api.PsActive},  // Serve
+		{api.PsInactive, api.PsActive},  // Activate
 		{api.PsActive, api.PsInactive},  // Deactivate
 		{api.PsInactive, api.PsDropped}, // Drop
 

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -276,7 +276,7 @@ func (n *TestNode) RPCs() []interface{} {
 		case *pb.ServeRequest:
 			return 200 + int(v.Range)
 
-		case *pb.TakeRequest:
+		case *pb.DeactivateRequest:
 			return 300 + int(v.Range)
 
 		case *pb.DropRequest:

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -21,7 +21,7 @@ import (
 type Action uint8
 
 const (
-	PrepareAddRange Action = iota
+	Prepare Action = iota
 	AddRange
 	PrepareDropRange
 	DropRange
@@ -51,7 +51,7 @@ type TestNode struct {
 	rpcsMu sync.Mutex
 
 	// Barriers to block on in the middle of range state changes. This allows
-	// tests to control exactly how long the interface methods (PrepareAddRange,
+	// tests to control exactly how long the interface methods (Prepare,
 	// AddRange, etc) take to return.
 	barriers map[api.RangeID]*stateTransition
 	muBar    sync.Mutex
@@ -147,8 +147,8 @@ func (n *TestNode) GetLoadInfo(rID api.RangeID) (api.LoadInfo, error) {
 	return li, nil
 }
 
-func (n *TestNode) PrepareAddRange(m api.Meta, p []api.Parent) error {
-	return n.transition(m.Ident, PrepareAddRange)
+func (n *TestNode) Prepare(m api.Meta, p []api.Parent) error {
+	return n.transition(m.Ident, Prepare)
 }
 
 func (n *TestNode) AddRange(rID api.RangeID) error {

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -22,7 +22,7 @@ type Action uint8
 
 const (
 	Prepare Action = iota
-	AddRange
+	Activate
 	Deactivate
 	Drop
 )
@@ -52,7 +52,7 @@ type TestNode struct {
 
 	// Barriers to block on in the middle of range state changes. This allows
 	// tests to control exactly how long the interface methods (Prepare,
-	// AddRange, etc) take to return.
+	// Activate, etc) take to return.
 	barriers map[api.RangeID]*stateTransition
 	muBar    sync.Mutex
 
@@ -151,8 +151,8 @@ func (n *TestNode) Prepare(m api.Meta, p []api.Parent) error {
 	return n.transition(m.Ident, Prepare)
 }
 
-func (n *TestNode) AddRange(rID api.RangeID) error {
-	return n.transition(rID, AddRange)
+func (n *TestNode) Activate(rID api.RangeID) error {
+	return n.transition(rID, Activate)
 }
 
 func (n *TestNode) Deactivate(rID api.RangeID) error {

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -270,7 +270,7 @@ func (n *TestNode) RPCs() []interface{} {
 	val := func(i int) int {
 
 		switch v := ret[i].(type) {
-		case *pb.GiveRequest:
+		case *pb.PrepareRequest:
 			return 100 + int(v.Range.Ident)
 
 		case *pb.ServeRequest:

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -23,7 +23,7 @@ type Action uint8
 const (
 	Prepare Action = iota
 	AddRange
-	PrepareDropRange
+	Deactivate
 	DropRange
 )
 
@@ -155,8 +155,8 @@ func (n *TestNode) AddRange(rID api.RangeID) error {
 	return n.transition(rID, AddRange)
 }
 
-func (n *TestNode) PrepareDropRange(rID api.RangeID) error {
-	return n.transition(rID, PrepareDropRange)
+func (n *TestNode) Deactivate(rID api.RangeID) error {
+	return n.transition(rID, Deactivate)
 }
 
 func (n *TestNode) DropRange(rID api.RangeID) error {

--- a/pkg/test/fake_node/fake_node.go
+++ b/pkg/test/fake_node/fake_node.go
@@ -24,7 +24,7 @@ const (
 	Prepare Action = iota
 	AddRange
 	Deactivate
-	DropRange
+	Drop
 )
 
 type stateTransition struct {
@@ -159,9 +159,9 @@ func (n *TestNode) Deactivate(rID api.RangeID) error {
 	return n.transition(rID, Deactivate)
 }
 
-func (n *TestNode) DropRange(rID api.RangeID) error {
+func (n *TestNode) Drop(rID api.RangeID) error {
 	// TODO: Remove placement from loadinfos if transition succeeds?
-	return n.transition(rID, DropRange)
+	return n.transition(rID, Drop)
 }
 
 // From: https://harrigan.xyz/blog/testing-go-grpc-server-using-an-in-memory-buffer-with-bufconn/


### PR DESCRIPTION
Whew, this was a lot of renaming stuff. Command (and state) naming always been inconsistent, with the (at least) two naming schemes for commands. Internally (golang) it was using the arbitrary give/take/serve/drop terms I made up, and externally (proto) it was using PrepareAdd/Add/PrepareDrop/Drop I terms borrowed from Shard Manager. Much has changed since back then, so this unifies command naming to **Prepare/Activate/Deactivate/Drop**, and placement/remote state naming similar to that.

The main reason that I moved away from the Shard Manager terms is to emphasize the symmetrical Activate/Deactivate commands which I think are necessary for some stateful services to recover gracefully from complex split/join failures. Naming those Add/PrepareDrop is confusing, given my model, because "prepare to drop" does not imply that the command might well be rolled back. (Indeed I went down a bit of a rabbit-hole in #6 trying to provide a sensible interface to that with "Untake".) I suspect that failure recovery is more complex for Ranger than Shard Manager, because of my highly questionable foundational decision to support key-range based splits and joins, as opposed to fixed shards; one imagines there are fewer things which can go wrong (e.g. one side of a split crashing while activating, after the other side has already activated) when moving around fixed shards. Either way, things which are different should have different names.

The resulting [placement state machine](https://github.com/adammck/ranger/blob/terminology/pkg/ranje/placement_state_transition.go) now looks like:

```mermaid
stateDiagram-v2
    direction LR
    [*] --> Pending
    Pending --> Inactive: Prepare
    Inactive --> Active: Activate
    Active --> Inactive: Deactivate
    Inactive --> NotFound: Drop
    NotFound --> [*]
```

If a command fails, then the placement remains in its previous state, rather than moving to some intermediate state. Nodes are expected to support that, and they can always crash or drop the range instead if they _really_ can't.

Or if we include the regrettable `PsMissing` state, which occurs when a range mysteriously disappears from a node (because of a crash or a bug):

```mermaid
stateDiagram-v2
    direction LR
    [*] --> Pending
    Pending --> Missing
    Inactive --> Missing
    Active --> Missing
    Missing --> NotFound
    Pending --> Inactive: Prepare
    Inactive --> Active: Activate
    Active --> Inactive: Deactivate
    Inactive --> NotFound: Drop
    NotFound --> [*]
```

Just for good measure, here's the corresponding [remote state machine](https://github.com/adammck/ranger/blob/terminology/pkg/api/remote_state.go). (There is actually no strict machine for this, because we must assume that nodes may go haywire and assume totally arbitrary remote states sometimes. So any state may instantly change to any other. But here's the _expected_ transitions.)

```mermaid
stateDiagram-v2
    direction LR
    [*] --> NsPreparing: Prepare
    NsPreparing --> NsInactive
    NsInactive --> NsActivating: Activate
    NsActivating --> NsActive
    NsActive --> NsDeactivating: Deactivate
    NsDeactivating --> NsInactive
    NsInactive --> NsDropping: Drop
    NsDropping --> NsNotFound
    NsNotFound --> [*]
```